### PR TITLE
Bump version to 0.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,3 @@ group :benchmarks do
   gem 'fast_attributes'
   gem 'attrio'
 end
-
-gem 'dry-logic', git: 'https://github.com/dry-rb/dry-logic.git', branch: 'master'
-gem 'dry-types', git: 'https://github.com/dry-rb/dry-types.git', branch: 'master'

--- a/dry-struct.gemspec
+++ b/dry-struct.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'dry-struct'
-  spec.version       = '0.0.0'
+  spec.version       = '0.0.1'
   spec.authors       = ['Piotr Solnica']
   spec.email         = ['piotr.solnica@gmail.com']
   spec.license       = 'MIT'

--- a/dry-struct.gemspec
+++ b/dry-struct.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dry-equalizer', '~> 0.2'
   spec.add_runtime_dependency 'dry-configurable', '~> 0.1'
   spec.add_runtime_dependency 'dry-logic', '~> 0.2', '>= 0.2.3'
-  spec.add_runtime_dependency 'dry-types', '~> 0.7', '>= 0.7.2'
+  spec.add_runtime_dependency 'dry-types', '~> 0.8', '>= 0.8.1'
   spec.add_runtime_dependency 'ice_nine', '~> 0.11'
 
   spec.add_development_dependency 'bundler', '~> 1.6'

--- a/lib/dry/struct/version.rb
+++ b/lib/dry/struct/version.rb
@@ -1,5 +1,5 @@
 module Dry
   class Struct
-    VERSION = '0.0.0'.freeze
+    VERSION = '0.0.1'.freeze
   end
 end

--- a/spec/dry/struct/version_spec.rb
+++ b/spec/dry/struct/version_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe Dry::Struct::VERSION do
+  let(:gemspec_path) { DryStructSpec::ROOT.join('dry-struct.gemspec').to_s }
+
+  it 'matches specification version' do
+    specification = Gem::Specification.load(gemspec_path)
+
+    expect(Dry::Struct::VERSION).to eql(specification.version.to_s)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,9 +3,14 @@ if RUBY_ENGINE == 'rbx'
   CodeClimate::TestReporter.start
 end
 
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-
 require 'pathname'
+
+module DryStructSpec
+  ROOT = Pathname.new(__dir__).parent.expand_path.freeze
+end
+
+$LOAD_PATH.unshift DryStructSpec::ROOT.join('lib').to_s
+
 require 'dry-struct'
 
 begin


### PR DESCRIPTION
- Bump version to 0.0.1 for first rubygem release
- Update dry-types dependency

---

For some reason dry-configurable breaks if I add a require for `dry/struct/version` in the gemspec:

```diff
diff --git i/dry-struct.gemspec w/dry-struct.gemspec
index 4e3e085..91acbb7 100644
--- i/dry-struct.gemspec
+++ w/dry-struct.gemspec
@@ -1,5 +1,8 @@
 # coding: utf-8

+root = File.expand_path(__dir__)
+require File.join(root, 'lib/dry/struct/version.rb')
+
 Gem::Specification.new do |spec|
   spec.name          = 'dry-struct'
   spec.version       = '0.0.0'
```

the specs fail before even running. Specifically I run into
`'initialize': wrong number of arguments (given 3, expected 0)` from
dry-configurable-0.1.6/lib/dry/configurable.rb:53

As a stopgap I am opening an issue with dry-configurable for this error
and also opening an issue on dry-struct to track this fix. I've added a
test to make sure that the `Dry::Struct::VERSION` and `dry-struct.gemspec`
version match to help me avoid pushing a bad release. I plan to remove this
test once I can simple put `Dry::Struct::VERSION` in the gemspec.