### PR TITLE
Symbolize hash keys in a constructor

### DIFF
--- a/lib/dry/struct.rb
+++ b/lib/dry/struct.rb
@@ -2,6 +2,7 @@ require 'dry-types'
 
 require 'dry/struct/version'
 require 'dry/struct/errors'
+require 'dry/struct/symbolize_keys'
 require 'dry/struct/class_interface'
 require 'dry/struct/hashify'
 require 'dry/struct/value'

--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -68,7 +68,7 @@ module Dry
         if attributes.instance_of?(self)
           attributes
         else
-          super(constructor[attributes])
+          super(constructor[SymbolizeKeys[attributes]])
         end
       rescue Types::SchemaError, Types::SchemaKeyError => error
         raise Struct::Error, "[#{self}.new] #{error}"

--- a/lib/dry/struct/symbolize_keys.rb
+++ b/lib/dry/struct/symbolize_keys.rb
@@ -1,0 +1,14 @@
+# Symbolizes keys in a hash (at the top level, without nesting)
+
+module Dry
+  class Struct
+    module SymbolizeKeys
+      def self.[](value)
+        return value unless value.respond_to?(:to_hash)
+        value.to_hash.each_with_object({}) do |(key, val), hash|
+          hash[key.to_sym] = val
+        end
+      end
+    end
+  end
+end

--- a/spec/dry/types/struct_spec.rb
+++ b/spec/dry/types/struct_spec.rb
@@ -46,6 +46,21 @@ RSpec.describe Dry::Struct do
       )
     end
 
+    it 'accepts hashes with stringified keys' do
+      address = Test::Address.new('city' => 'NYC', 'zipcode' => '312')
+      user = user_type['name' => 'Jane', 'age' => 21, 'address' => address]
+
+      expect(user.address).to be(address)
+    end
+
+    it 'accepts any value that support #to_hash' do
+      address = double to_hash: { 'city' => 'NYC', 'zipcode' => '312' }
+      user = user_type[name: 'Jane', age: 21, address: address]
+
+      expect(user.address)
+        .to eq(Test::Address.new('city' => 'NYC', 'zipcode' => '312'))
+    end
+
     it 'passes through values when they are structs already' do
       address = Test::Address.new(city: 'NYC', zipcode: '312')
       user = user_type[name: 'Jane', age: 21, address: address]


### PR DESCRIPTION
Now a structure can be initialized by a hash with either symbolic,
or string keys:

```ruby
class User < Dry::Struct
  # ...
end

User.new name: 'Jane'    # traditional behaviour
User.new 'name' => 'Joe' # the new one
```

It also accepts every object that responds to `#to_hash`:

```ruby
User.new double(to_hash: { 'name' => 'Judith' })
```

The constructor ignores `#to_h` (to prevent `nil` from being hashified):

```ruby
User.new double(to_h: { name: 'Jill' }) # fails
```
