### PR TITLE
Fix warnings "instance variable not initialized"

### DIFF
--- a/lib/dry/struct.rb
+++ b/lib/dry/struct.rb
@@ -10,6 +10,8 @@ module Dry
   class Struct
     extend ClassInterface
 
+    constructor_type(:strict)
+
     def initialize(attributes)
       attributes.each { |key, value| instance_variable_set("@#{key}", value) }
     end

--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -11,9 +11,14 @@ module Dry
 
       protected :constructor=, :equalizer=, :constructor_type=
 
+      def self.extended(base)
+        base.instance_variable_set(:@schema, {})
+      end
+
       def inherited(klass)
         super
 
+        klass.instance_variable_set(:@schema, {})
         klass.equalizer = Equalizer.new(*schema.keys)
         klass.constructor_type = constructor_type
         klass.send(:include, klass.equalizer)

--- a/lib/dry/struct/value.rb
+++ b/lib/dry/struct/value.rb
@@ -1,7 +1,5 @@
 require 'ice_nine'
 
-require 'dry/struct'
-
 module Dry
   class Struct
     class Value < self

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ module DryStructSpec
 end
 
 $LOAD_PATH.unshift DryStructSpec::ROOT.join('lib').to_s
+$VERBOSE = true
 
 require 'dry-struct'
 


### PR DESCRIPTION
There was a problem with variables @schema and @constructor_type
when using and loading dry-struct. The place where those should be initialized -
missed. After experimenting a bit I found on which cases we use  variables
without initialization:
  - when we extending Dry::Struct with ClassInterface
  - when we inheriting any class from Dry::Struct or its successor

This all caused by the rule that class ivars are not shared with
successors. So we need to initialize them in a hook or like that.

In my solution:
  - @constructor_type is initialized by its writer in body of Dry::Struct class
  - @schema is initialized in ```extended``` and ```inherited``` hooks

Also there was a huge warning "loading in progress, circular require..."
in lib/struct/value.rb, now - seems fixed.


Closes https://github.com/dry-rb/dry-types/issues/77