### PR TITLE
Update dry-struct to latest dry-types

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'dry-types', github: 'dry-rb/dry-types', branch: 'master'
+gem 'dry-logic', github: 'dry-rb/dry-logic', branch: 'master'
 
 group :test do
   gem 'codeclimate-test-reporter', platform: :mri, require: false

--- a/lib/dry/struct.rb
+++ b/lib/dry/struct.rb
@@ -10,7 +10,7 @@ module Dry
   class Struct
     extend ClassInterface
 
-    constructor_type(:strict)
+    constructor_type(:permissive)
 
     def initialize(attributes)
       attributes.each { |key, value| instance_variable_set("@#{key}", value) }

--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -77,7 +77,7 @@ module Dry
         else
           super(constructor[attributes])
         end
-      rescue Types::SchemaError, Types::SchemaKeyError => error
+      rescue Types::SchemaError, Types::MissingKeyError, Types::UnknownKeysError => error
         raise Struct::Error, "[#{self}.new] #{error}"
       end
       alias_method :call, :new
@@ -94,6 +94,18 @@ module Dry
       rescue Struct::Error => e
         failure = Types::Result::Failure.new(input, e.message)
         block_given? ? yield(failure) : failure
+      end
+
+      def success(*args)
+        result(Types::Result::Success, *args)
+      end
+
+      def failure(*args)
+        result(Types::Result::Failure, *args)
+      end
+
+      def result(klass, *args)
+        klass.new(*args)
       end
 
       def maybe?


### PR DESCRIPTION
 - dry-logic is now pegged to the master branch on github until dry-types and dry-logic are released

 - The default constructor_type is now `:permissive` (which is the same as the old behavior but renamed to make room for the real strict constructor_type)

 - Add `success` and `failure` to the class interface of dry struct to conform with the interface that Dry::Types::Definition requires