### PR TITLE
Fixed warnings about use of undefined instance variables

### DIFF
--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -13,14 +13,9 @@ module Dry
 
       protected :constructor=, :equalizer=, :constructor_type=
 
-      def self.extended(base)
-        base.instance_variable_set(:@schema, {})
-      end
-
       def inherited(klass)
         super
 
-        klass.instance_variable_set(:@schema, {})
         klass.equalizer = Equalizer.new(*schema.keys)
         klass.constructor_type = constructor_type
         klass.send(:include, klass.equalizer)
@@ -58,16 +53,15 @@ module Dry
       private :check_schema_duplication
 
       def constructor_type(type = nil)
-        if type
-          @constructor_type = type
-        else
-          @constructor_type || :strict
-        end
+        @constructor_type ||= :strict
+        @constructor_type = type if type
+        @constructor_type
       end
 
       def schema
+        @schema ||= {}
         super_schema = superclass.respond_to?(:schema) ? superclass.schema : {}
-        super_schema.merge(@schema || {})
+        super_schema.merge(@schema)
       end
 
       def new(attributes = default_attributes)


### PR DESCRIPTION
I removed where `instance_variable_set` was used to attempt to set `@schema` because that was being called on the class rather than an instance.

For @constructor_type, I reorganized the method to use the `||=` memoization pattern to assign the constructor_type to the default of :strict (which was the intention of the code as I read it).

Specs pass.

Addresses Issue #19 
