### PR TITLE
YARD documentation for Dry::Struct

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,4 @@
+--title 'dry-struct'
+--markup markdown
+--readme README.md
+lib/**/*.rb

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,7 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
+
+require 'yard'
+require 'yard/rake/yardoc_task'
+YARD::Rake::YardocTask.new(:doc)

--- a/dry-struct.gemspec
+++ b/dry-struct.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake', '~> 11.0'
   spec.add_development_dependency 'rspec', '~> 3.3'
+  spec.add_development_dependency 'yard', '~> 0.9.5'
 end

--- a/lib/dry/struct.rb
+++ b/lib/dry/struct.rb
@@ -7,19 +7,107 @@ require 'dry/struct/hashify'
 require 'dry/struct/value'
 
 module Dry
+  # Typed {Struct} with virtus-like DSL for defining schema.
+  #
+  # ### Differences between dry-struct and virtus
+  #
+  # {Struct} look somewhat similar to [Virtus][] but there are few significant differences:
+  #
+  # * {Struct}s don't provide attribute writers and are meant to be used
+  #   as "data objects" exclusively.
+  # * Handling of attribute values is provided by standalone type objects from
+  #   [`dry-types`][].
+  # * Handling of attribute hashes is provided by standalone hash schemas from
+  #   [`dry-types`][], which means there are different types of constructors in
+  #   {Struct} (see {Dry::Struct::ClassInterface#constructor_type})
+  # * Struct classes quack like [`dry-types`][], which means you can use them
+  #   in hash schemas, as array members or sum them
+  #
+  # {Struct} class can specify a constructor type, which uses [hash schemas][]
+  # to handle attributes in `.new` method.
+  # See {ClassInterface#new} for constructor types descriptions and examples.
+  #
+  # [`dry-types`]: https://github.com/dry-rb/dry-types
+  # [Virtus]: https://github.com/solnic/virtus
+  # [hash schemas]: http://dry-rb.org/gems/dry-types/hash-schemas
+  #
+  # @example
+  #   require 'dry-struct'
+  #
+  #   module Types
+  #     include Dry::Types.module
+  #   end
+  #
+  #   class Book < Dry::Struct
+  #     attribute :title, Types::Strict::String
+  #     attribute :subtitle, Types::Strict::String.optional
+  #   end
+  #
+  #   rom_n_roda = Book.new(
+  #     title: 'Web Development with ROM and Roda',
+  #     subtitle: nil
+  #   )
+  #   rom_n_roda.title #=> 'Web Development with ROM and Roda'
+  #   rom_n_roda.subtitle #=> nil
+  #
+  #   refactoring = Book.new(
+  #     title: 'Refactoring',
+  #     subtitle: 'Improving the Design of Existing Code'
+  #   )
+  #   refactoring.title #=> 'Refactoring'
+  #   refactoring.subtitle #=> 'Improving the Design of Existing Code'
   class Struct
     extend ClassInterface
 
+    # @overload constructor_type
+    #   Returns the constructor type for {Struct}
+    #   @return [Symbol] (:permissive)
+    #   @see ClassInterface#constructor_type
     constructor_type(:permissive)
 
+    # @param [Hash, #each] attributes
     def initialize(attributes)
       attributes.each { |key, value| instance_variable_set("@#{key}", value) }
     end
 
+    # Retrieves value of previously defined attribute by its' `name`
+    #
+    # @param [String] name
+    # @return [Object]
+    #
+    # @example
+    #   class Book < Dry::Struct
+    #     attribute :title, Types::Strict::String
+    #     attribute :subtitle, Types::Strict::String.optional
+    #   end
+    #
+    #   rom_n_roda = Book.new(
+    #     title: 'Web Development with ROM and Roda',
+    #     subtitle: nil
+    #   )
+    #   rom_n_roda[:title] #=> 'Web Development with ROM and Roda'
+    #   rom_n_roda[:subtitle] #=> nil
     def [](name)
       public_send(name)
     end
 
+    # Converts the {Dry::Struct} to a hash with keys representing
+    # each attribute (as symbols) and their corresponding values
+    #
+    # @return [Hash{Symbol => Object}]
+    #
+    # @example
+    #   class Book < Dry::Struct
+    #     attribute :title, Types::Strict::String
+    #     attribute :subtitle, Types::Strict::String.optional
+    #   end
+    #
+    #   rom_n_roda = Book.new(
+    #     title: 'Web Development with ROM and Roda',
+    #     subtitle: nil
+    #   )
+    #   rom_n_roda.to_hash
+    #     #=> {title: 'Web Development with ROM and Roda', subtitle: nil}
     def to_hash
       self.class.schema.keys.each_with_object({}) do |key, result|
         result[key] = Hashify[self[key]]

--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -106,6 +106,16 @@ module Dry
 
       # Sets or retrieves {#constructor} type as a symbol
       #
+      # @note All examples below assume that you have defined {Struct} with
+      #   following attributes and explicitly call only {#constructor_type}:
+      #
+      #   ```ruby
+      #   class User < Dry::Struct
+      #     attribute :name, Types::Strict::String.default('John Doe')
+      #     attribute :age, Types::Strict::Int
+      #   end
+      #   ```
+      #
       # ### Common constructor types include:
       #
       # * `:permissive` - the default constructor type, useful for defining
@@ -121,11 +131,6 @@ module Dry
       #   you specified as attributes* in the input hash
       # * `:strict_with_defaults` - same as `:strict` but you are OK that some
       #   values may be nil and you want defaults to be set
-      # * `:weak` and `:symbolized` - *don't use those with {Struct}*,
-      #   and instead use [`dry-validation`][] to process and validate
-      #   attributes, otherwise your struct will behave as a data validator
-      #   which raises exceptions on invalid input (assuming your attributes
-      #   types are strict)
       #
       # To feel the difference between constructor types, look into examples.
       # Each of them provide the same attributes' definitions,
@@ -136,14 +141,16 @@ module Dry
       # 3. Input contains nil for a value that specifies a default
       # 4. Input includes a key that was not specified in the schema
       #
-      # [`dry-validation`]: https://github.com/dry-rb/dry-validation
+      # @note Don’t use `:weak` and `:symbolized` as {#constructor_type},
+      #   and instead use [`dry-validation`][] to process and validate
+      #   attributes, otherwise your struct will behave as a data validator
+      #   which raises exceptions on invalid input (assuming your attributes
+      #   types are strict)
+      #   [`dry-validation`]: https://github.com/dry-rb/dry-validation
       #
       # @example `:permissive` constructor
       #   class User < Dry::Struct
       #     constructor_type :permissive
-      #
-      #     attribute :name, Types::Strict::String.default('John Doe')
-      #     attribute :age, Types::Strict::Int
       #   end
       #
       #   User.new(name: "Jane")
@@ -158,9 +165,6 @@ module Dry
       # @example `:schema` constructor
       #   class User < Dry::Struct
       #     constructor_type :schema
-      #
-      #     attribute :name, Types::Strict::String.default('John Doe')
-      #     attribute :age, Types::Strict::Int
       #   end
       #
       #   User.new(name: "Jane")        #=> #<User name="Jane" age=nil>
@@ -172,9 +176,6 @@ module Dry
       # @example `:strict` constructor
       #   class User < Dry::Struct
       #     constructor_type :strict
-      #
-      #     attribute :name, Types::Strict::String.default('John Doe')
-      #     attribute :age, Types::Strict::Int
       #   end
       #
       #   User.new(name: "Jane")
@@ -189,9 +190,6 @@ module Dry
       # @example `:strict_with_defaults` constructor
       #   class User < Dry::Struct
       #     constructor_type :strict_with_defaults
-      #
-      #     attribute :name, Types::Strict::String.default('John Doe')
-      #     attribute :age, Types::Strict::Int
       #   end
       #
       #   User.new(name: "Jane")
@@ -253,6 +251,8 @@ module Dry
       end
 
       # @param [Hash{Symbol => Object}] input
+      # @yieldparam [Dry::Types::Result::Failure] failure
+      # @yieldreturn [Dry::Types::ResultResult]
       # @return [Dry::Types::Result]
       def try(input)
         Types::Result::Success.new(self[input])
@@ -279,7 +279,7 @@ module Dry
         klass.new(*args)
       end
 
-      # @return [Boolean]
+      # @return [false]
       def default?
         false
       end
@@ -290,12 +290,12 @@ module Dry
         self === value
       end
 
-      # @return [Boolean]
+      # @return [true]
       def constrained?
         true
       end
 
-      # @return [Dry::Struct]
+      # @return [self]
       def primitive
         self
       end

--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -2,21 +2,30 @@ require 'dry/struct/errors'
 
 module Dry
   class Struct
+    # Class-level interface of {Struct} and {Value}
     module ClassInterface
       include Dry::Types::Builder
 
+      # {Dry::Types::Hash} subclass with specific behaviour defined for
+      # @return [Dry::Types::Hash]
+      # @see #constructor_type
       attr_accessor :constructor
 
+      # @return [Dry::Equalizer]
       attr_accessor :equalizer
 
+      # @return [Symbol]
+      # @see #constructor_type
       attr_writer :constructor_type
 
       protected :constructor=, :equalizer=, :constructor_type=
 
+      # @param [Module] base
       def self.extended(base)
         base.instance_variable_set(:@schema, {})
       end
 
+      # @param [Class] klass
       def inherited(klass)
         super
 
@@ -32,10 +41,45 @@ module Dry
         klass.attributes({}) unless equal?(Struct)
       end
 
+      # Adds an attribute for this {Struct} with given `name` and `type`
+      # and modifies {.schema} accordingly.
+      #
+      # @param [Symbol] name name of the defined attribute
+      # @param [Dry::Types::Definition] type
+      # @return [Dry::Struct]
+      # @raise [RepeatedAttributeError] when trying to define attribute with the
+      #   same name as previously defined one
+      #
+      # @example
+      #   class Language < Dry::Struct
+      #     attribute :name, Types::String
+      #   end
+      #
+      #   Language.schema
+      #     #=> {name: #<Dry::Types::Definition primitive=String options={}>}
+      #
+      #   ruby = Language.new(name: 'Ruby')
+      #   ruby.name #=> 'Ruby'
       def attribute(name, type)
         attributes(name => type)
       end
 
+      # @param [Hash{Symbol => Dry::Types::Definition}] new_schema
+      # @return [Dry::Struct]
+      # @raise [RepeatedAttributeError] when trying to define attribute with the
+      #   same name as previously defined one
+      # @see #attribute
+      # @example
+      #   class Book1 < Dry::Struct
+      #     attributes(
+      #       title: Types::String,
+      #       author: Types::String
+      #     )
+      #   end
+      #
+      #   Book.schema
+      #     #=> {title: #<Dry::Types::Definition primitive=String options={}>,
+      #     #    author: #<Dry::Types::Definition primitive=String options={}>}
       def attributes(new_schema)
         check_schema_duplication(new_schema)
 
@@ -50,6 +94,9 @@ module Dry
         self
       end
 
+      # @param [Hash{Symbol => Dry::Types::Definition, Dry::Struct}] new_schema
+      # @raise [RepeatedAttributeError] when trying to define attribute with the
+      #   same name as previously defined one
       def check_schema_duplication(new_schema)
         shared_keys = new_schema.keys & schema.keys
 
@@ -57,6 +104,115 @@ module Dry
       end
       private :check_schema_duplication
 
+      # Sets or retrieves {#constructor} type as a symbol
+      #
+      # ### Common constructor types include:
+      #
+      # * `:permissive` - the default constructor type, useful for defining
+      #   {Struct}s that are instantiated using data from the database
+      #   (i.e. results of a database query), where you expect *all defined
+      #   attributes to be present* and it's OK to ignore other keys
+      #   (i.e. keys used for joining, that are not relevant from your domain
+      #   {Struct}s point of view). Default values **are not used** otherwise
+      #   you wouldn't notice missing data.
+      # * `:schema` - missing keys will result in setting them using default
+      #   values, unexpected keys will be ignored.
+      # * `:strict` - useful when you *do not expect keys other than the ones
+      #   you specified as attributes* in the input hash
+      # * `:strict_with_defaults` - same as `:strict` but you are OK that some
+      #   values may be nil and you want defaults to be set
+      # * `:weak` and `:symbolized` - *don't use those with {Struct}*,
+      #   and instead use [`dry-validation`][] to process and validate
+      #   attributes, otherwise your struct will behave as a data validator
+      #   which raises exceptions on invalid input (assuming your attributes
+      #   types are strict)
+      #
+      # To feel the difference between constructor types, look into examples.
+      # Each of them provide the same attributes' definitions,
+      # different constructor type, and 4 cases of given input:
+      #
+      # 1. Input omits a key for a value that does not have a default
+      # 2. Input omits a key for a value that has a default
+      # 3. Input contains nil for a value that specifies a default
+      # 4. Input includes a key that was not specified in the schema
+      #
+      # [`dry-validation`]: https://github.com/dry-rb/dry-validation
+      #
+      # @example `:permissive` constructor
+      #   class User < Dry::Struct
+      #     constructor_type :permissive
+      #
+      #     attribute :name, Types::Strict::String.default('John Doe')
+      #     attribute :age, Types::Strict::Int
+      #   end
+      #
+      #   User.new(name: "Jane")
+      #     #=> Dry::Struct::Error: [User.new] :age is missing in Hash input
+      #   User.new(age: 31)
+      #     #=> Dry::Struct::Error: [User.new] :name is missing in Hash input
+      #   User.new(name: nil, age: 31)
+      #     #=> #<User name="John Doe" age=31>
+      #   User.new(name: "Jane", age: 31, unexpected: "attribute")
+      #     #=> #<User name="Jane" age=31>
+      #
+      # @example `:schema` constructor
+      #   class User < Dry::Struct
+      #     constructor_type :schema
+      #
+      #     attribute :name, Types::Strict::String.default('John Doe')
+      #     attribute :age, Types::Strict::Int
+      #   end
+      #
+      #   User.new(name: "Jane")        #=> #<User name="Jane" age=nil>
+      #   User.new(age: 31)             #=> #<User name="John Doe" age=31>
+      #   User.new(name: nil, age: 31)  #=> #<User name="John Doe" age=31>
+      #   User.new(name: "Jane", age: 31, unexpected: "attribute")
+      #     #=> #<User name="Jane" age=31>
+      #
+      # @example `:strict` constructor
+      #   class User < Dry::Struct
+      #     constructor_type :strict
+      #
+      #     attribute :name, Types::Strict::String.default('John Doe')
+      #     attribute :age, Types::Strict::Int
+      #   end
+      #
+      #   User.new(name: "Jane")
+      #     #=> Dry::Struct::Error: [User.new] :age is missing in Hash input
+      #   User.new(age: 31)
+      #     #=> Dry::Struct::Error: [User.new] :name is missing in Hash input
+      #   User.new(name: nil, age: 31)
+      #     #=> Dry::Struct::Error: [User.new] nil (NilClass) has invalid type for :name
+      #   User.new(name: "Jane", age: 31, unexpected: "attribute")
+      #     #=> Dry::Struct::Error: [User.new] unexpected keys [:unexpected] in Hash input
+      #
+      # @example `:strict_with_defaults` constructor
+      #   class User < Dry::Struct
+      #     constructor_type :strict_with_defaults
+      #
+      #     attribute :name, Types::Strict::String.default('John Doe')
+      #     attribute :age, Types::Strict::Int
+      #   end
+      #
+      #   User.new(name: "Jane")
+      #     #=> Dry::Struct::Error: [User.new] :age is missing in Hash input
+      #   User.new(age: 31)
+      #     #=> #<User name="John Doe" age=31>
+      #   User.new(name: nil, age: 31)
+      #     #=> Dry::Struct::Error: [User.new] nil (NilClass) has invalid type for :name
+      #   User.new(name: "Jane", age: 31, unexpected: "attribute")
+      #     #=> Dry::Struct::Error: [User.new] unexpected keys [:unexpected] in Hash input
+      #
+      # @see http://dry-rb.org/gems/dry-types/hash-schemas
+      #
+      # @overload constructor_type(type)
+      #   Sets the constructor type for {Struct}
+      #   @param [Symbol] type one of constructor types, see above
+      #   @return [Symbol]
+      #
+      # @overload constructor_type
+      #   Returns the constructor type for {Struct}
+      #   @return [Symbol] (:strict)
       def constructor_type(type = nil)
         if type
           @constructor_type = type
@@ -65,11 +221,15 @@ module Dry
         end
       end
 
+      # @return [Hash{Symbol => Dry::Types::Definition, Dry::Struct}]
       def schema
         super_schema = superclass.respond_to?(:schema) ? superclass.schema : {}
         super_schema.merge(@schema || {})
       end
 
+      # @param [Hash{Symbol => Object}] attributes
+      # @raise [Struct::Error] if the given attributes don't conform {#schema}
+      #   with given {#constructor_type}
       def new(attributes = default_attributes)
         if attributes.instance_of?(self)
           attributes
@@ -82,12 +242,18 @@ module Dry
       alias_method :call, :new
       alias_method :[], :new
 
+      # Retrieves default attributes from defined {.schema}.
+      # Used in a {Struct} constructor if no attributes provided to {.new}
+      #
+      # @return [Hash{Symbol => Object}]
       def default_attributes
         schema.each_with_object({}) { |(name, type), result|
           result[name] = type.default? ? type.evaluate : type[nil]
         }
       end
 
+      # @param [Hash{Symbol => Object}] input
+      # @return [Dry::Types::Result]
       def try(input)
         Types::Result::Success.new(self[input])
       rescue Struct::Error => e
@@ -95,30 +261,41 @@ module Dry
         block_given? ? yield(failure) : failure
       end
 
+      # @param [({Symbol => Object})] args
+      # @return [Dry::Types::Result::Success]
       def success(*args)
         result(Types::Result::Success, *args)
       end
 
+      # @param [({Symbol => Object})] args
+      # @return [Dry::Types::Result::Failure]
       def failure(*args)
         result(Types::Result::Failure, *args)
       end
 
+      # @param [Class] klass
+      # @param [({Symbol => Object})] args
       def result(klass, *args)
         klass.new(*args)
       end
 
+      # @return [Boolean]
       def default?
         false
       end
 
+      # @param [Object, Dry::Struct] value
+      # @return [Boolean]
       def valid?(value)
         self === value
       end
 
+      # @return [Boolean]
       def constrained?
         true
       end
 
+      # @return [Dry::Struct]
       def primitive
         self
       end

--- a/lib/dry/struct/errors.rb
+++ b/lib/dry/struct/errors.rb
@@ -4,9 +4,13 @@ module Dry
 
     setting :namespace, self
 
+    # Raised when given input doesn't conform schema and constructor type
     Error = Class.new(TypeError)
 
+    # Raised when defining duplicate attributes
     class RepeatedAttributeError < ArgumentError
+      # @param [Symbol] key
+      #   attribute name that is the same as previously defined one
       def initialize(key)
         super("Attribute :#{key} has already been defined")
       end

--- a/lib/dry/struct/hashify.rb
+++ b/lib/dry/struct/hashify.rb
@@ -1,8 +1,10 @@
-# Converts value to hash recursively
-
 module Dry
   class Struct
+    # Helper for {Struct#to_hash} implementation
     module Hashify
+      # Converts value to hash recursively
+      # @param [#to_hash, #map, Object] value
+      # @return [Hash, Array]
       def self.[](value)
         if value.respond_to?(:to_hash)
           value.to_hash

--- a/lib/dry/struct/value.rb
+++ b/lib/dry/struct/value.rb
@@ -2,7 +2,26 @@ require 'ice_nine'
 
 module Dry
   class Struct
+    # {Value} objects behave like {Struct}s but *deeply frozen*
+    # using [`ice_nine`](https://github.com/dkubb/ice_nine)
+    #
+    # @example
+    #   class Location < Dry::Struct::Value
+    #     attribute :lat, Types::Strict::Float
+    #     attribute :lng, Types::Strict::Float
+    #   end
+    #
+    #   loc1 = Location.new(lat: 1.23, lng: 4.56)
+    #   loc2 = Location.new(lat: 1.23, lng: 4.56)
+    #
+    #   loc1.frozen? #=> true
+    #   loc2.frozen? #=> true
+    #   loc1 == loc2 #=> true
+    #
+    # @see https://github.com/dkubb/ice_nine
     class Value < self
+      # @see ClassInterface#new
+      # @see https://github.com/dkubb/ice_nine
       def self.new(*)
         IceNine.deep_freeze(super)
       end

--- a/lib/dry/struct/value.rb
+++ b/lib/dry/struct/value.rb
@@ -20,7 +20,8 @@ module Dry
     #
     # @see https://github.com/dkubb/ice_nine
     class Value < self
-      # @see ClassInterface#new
+      # @param (see ClassInterface#new)
+      # @return [Value]
       # @see https://github.com/dkubb/ice_nine
       def self.new(*)
         IceNine.deep_freeze(super)


### PR DESCRIPTION
I am continuing my work on documenting `dry-*` gems that I’ve started in dry-rb/dry-types#166. 

Now I have documented some `dry-struct` code. This time with more detailed comments and (my favorite part) clear examples for different constructor types and given input.