### PR TITLE
Raise ArgumentError when attribute type is a string and no value is supplied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 master
 
+## Added
+
+* Raise ArgumentError when attribute type is a string and no value provided is for `new` (GustavoCaso)
+
 ## Fixed
 
 * `.[]` and `.call` does not coerce subclass to superclass anymore (Kukunin)

--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -249,9 +249,19 @@ module Dry
       #
       # @return [Hash{Symbol => Object}]
       def default_attributes
+        check_invalid_schema_keys
         schema.each_with_object({}) { |(name, type), result|
           result[name] = type.default? ? type.evaluate : type[nil]
         }
+      end
+
+      def check_invalid_schema_keys
+        invalid_keys = schema.select { |name, type|  type.instance_of?(String) }
+        raise ArgumentError, argument_error_msg(invalid_keys.keys) if invalid_keys.any?
+      end
+
+      def argument_error_msg(keys)
+        "Invaild argument for #{keys.join(', ')}"
       end
 
       # @param [Hash{Symbol => Object}] input

--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -313,6 +313,11 @@ module Dry
       def primitive
         self
       end
+
+      # @return [false]
+      def optional?
+        false
+      end
     end
   end
 end

--- a/spec/dry/struct_spec.rb
+++ b/spec/dry/struct_spec.rb
@@ -46,6 +46,15 @@ RSpec.describe Dry::Struct do
       )
     end
 
+    it 'raise ArgumentError when the attributes types are strings' do
+      expect {
+        user_type.new
+      }.to raise_error(
+        ArgumentError,
+        'Invaild argument for name, age'
+      )
+    end
+
     it 'passes through values when they are structs already' do
       address = Test::Address.new(city: 'NYC', zipcode: '312')
       user = construct_user(name: 'Jane', age: 21, address: address)


### PR DESCRIPTION
#11 

@solnic I added the ArgumentError, by checking when no argument is added to the `new` method, and if the `type` of the `Struct` is a `string`
