### PR TITLE
Return itself if an object is an instance of subclass

### DIFF
--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -71,7 +71,7 @@ module Dry
       end
 
       def new(attributes = default_attributes)
-        if attributes.instance_of?(self)
+        if attributes.is_a?(self)
           attributes
         else
           super(constructor[attributes])

--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -71,7 +71,7 @@ module Dry
       end
 
       def new(attributes = default_attributes)
-        if attributes.is_a?(self)
+        if attributes.instance_of?(self)
           attributes
         else
           super(constructor[attributes])
@@ -79,8 +79,12 @@ module Dry
       rescue Types::SchemaError, Types::MissingKeyError, Types::UnknownKeysError => error
         raise Struct::Error, "[#{self}.new] #{error}"
       end
-      alias_method :call, :new
-      alias_method :[], :new
+
+      def call(attributes = default_attributes)
+        return attributes if attributes.is_a?(self)
+        new(attributes)
+      end
+      alias_method :[], :call
 
       def default_attributes
         schema.each_with_object({}) { |(name, type), result|

--- a/spec/dry/types/struct_spec.rb
+++ b/spec/dry/types/struct_spec.rb
@@ -53,6 +53,22 @@ RSpec.describe Dry::Struct do
       expect(user.address).to be(address)
     end
 
+    it 'returns itself when an object is an instance of given class' do
+      user = user_type[
+        name: :Jane, age: '21', address: { city: 'NYC', zipcode: 123 }
+      ]
+
+      expect(user_type[user]).to be_equal(user)
+    end
+
+    it 'returns itself when an object is an instance of subclass' do
+      user = root_type[
+        name: :Jane, age: '21', root: true, address: { city: 'NYC', zipcode: 123 }
+      ]
+
+      expect(user_type[user]).to be_equal(user)
+    end
+
     it 'creates an empty struct when called without arguments' do
       class Test::Empty < Dry::Struct
         @constructor = Dry::Types['strict.hash'].strict(schema)


### PR DESCRIPTION
According to LSP from SOLID, subclasses should preserve the same interface as superclass. 
Thus, it's needed to `Dry::Struct` to return an original subclass instance, not an instance coerced to a superclass.