### PR TITLE
Add Dry.Struct constructor method

### DIFF
--- a/lib/dry/struct.rb
+++ b/lib/dry/struct.rb
@@ -7,6 +7,32 @@ require 'dry/struct/class_interface'
 require 'dry/struct/hashify'
 
 module Dry
+  # Constructor method for easily creating a {Dry::Struct}.
+  # @return [Dry::Struct]
+  # @example
+  #   require 'dry-struct'
+  #
+  #   module Types
+  #     include Dry::Types.module
+  #   end
+  #
+  #   Person = Dry.Struct(name: Types::Strict::String, age: Types::Strict::Int)
+  #   matz = Person.new(name: "Matz", age: 52)
+  #   matz.name #=> "Matz"
+  #   matz.age #=> 52
+  #
+  #   Test = Dry.Struct(:strict, expected: Types::Strict::String)
+  #   Test[expected: "foo", unexpected: "bar"]
+  #   #=> Dry::Struct::Error: [Test.new] unexpected keys [:unexpected] in Hash input
+  # @see Dry::Struct#constructor_type
+  def self.Struct(constructor = :permissive, **attributes, &block)
+    klass = Class.new(Dry::Struct) do
+      constructor_type constructor
+      attributes.each { |a, type| attribute a, type }
+    end
+    klass.tap { |k| k.instance_eval(&block) if block }
+  end
+
   # Typed {Struct} with virtus-like DSL for defining schema.
   #
   # ### Differences between dry-struct and virtus

--- a/spec/dry_spec.rb
+++ b/spec/dry_spec.rb
@@ -1,0 +1,43 @@
+
+RSpec.describe Dry do
+  describe '.Struct' do
+    context 'constructor types' do
+      %i[permissive schema strict strict_with_defaults].each do |constructor|
+        it "returns a struct with constructor type #{constructor}" do
+          struct_klass = Dry.Struct(constructor, name: 'strict.string')
+          expect(struct_klass.constructor_type).to eq constructor
+
+          struct = struct_klass.new(name: 'Test')
+          expect(struct.__attributes__).to eq(name: 'Test')
+        end
+      end
+    end
+
+    context 'initializer block' do
+      before do
+        module Test
+          Library = Dry.Struct do
+            constructor_type :strict
+
+            attribute :library, 'strict.string'
+            attribute :language, 'strict.string'
+          end
+        end
+      end
+
+      it 'sets the correct constructor type' do
+        expect {
+          Test::Library.new(library: 'dry-rb')
+        }.to raise_error(
+          Dry::Struct::Error,
+          '[Test::Library.new] :language is missing in Hash input'
+        )
+      end
+
+      it 'sets the correct attributes' do
+        attributes = { library: 'dry-struct', language: 'Ruby' }
+        expect(Test::Library.new(attributes).to_h).to eql(attributes)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I originally [posted this as an idea on Discourse](https://discourse.dry-rb.org/t/dry-struct-factory-method-easier-type-constructor/365). @timriley expressed some interest and 2 other people "liked" the idea (whatever that's worth), but there was no other feedback. 

So before I go through the effort of writing YARD docs, adding specs etc. here's a barebones PR for further discussion. I'll also copy over the description from Discourse, so everything's in one place:

I've been playing around with `dry-struct` yesterday, and found nothing quite as compact as the following shorthand used with normal Ruby structs:

```ruby
Person = Struct.new(:age, :name)
```

Since there are already some capitalized methods that act like "type constructors" in `dry-rb`, I added a "factory method", `Dry.Struct`:

```ruby
Person = Dry.Struct(name: Types::String, age: Types::Int)
p = Person[name: "Test", age: 42]
#=> #<Person name="Test" age=42>
p.class
#=> Person
```

Like a standard `dry-struct` this defaults to `:permissive`, though you can override that easily:

```ruby
Test = Dry.Struct(:strict, expected: Types::String)
Test[expected: "foo", unexpected: "bar"]
#=> Dry::Struct::Error: [Test.new] unexpected keys [:unexpected] in Hash input
```

Last but not least there's the block form, which is nice if you want to be a bit more explicit/have longer attribute definitions with defaults etc. (contrived example):

```ruby
AllTheThings = Dry.Struct(:strict, name: Types::String) do
  attribute :age, Types::Strict::Int.optional
end
```
