### PR TITLE
Restrict use of weak and symbolize for constructor type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ script:
 after_success:
   - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
 rvm:
-  - 2.1.10
   - 2.2.7
   - 2.3.3
   - 2.4.1

--- a/dry-struct.gemspec
+++ b/dry-struct.gemspec
@@ -28,8 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'dry-equalizer', '~> 0.2'
   spec.add_runtime_dependency 'dry-configurable', '~> 0.1'
-  spec.add_runtime_dependency 'dry-types', '~> 0.9', '>= 0.9.0'
-  spec.add_runtime_dependency 'dry-core', '~> 0.3'
+  spec.add_runtime_dependency 'dry-core', '~> 0.4'
   spec.add_runtime_dependency 'ice_nine', '~> 0.11'
 
   spec.add_development_dependency 'bundler', '~> 1.6'

--- a/lib/dry/struct.rb
+++ b/lib/dry/struct.rb
@@ -70,9 +70,7 @@ module Dry
     defines :schema
     schema EMPTY_HASH
 
-    def self.valid_constructor_types
-      Dry::Types['symbol'].enum(:permissive, :schema, :strict, :strict_with_defaults)
-    end
+    CONSTRUCTOR_TYPE = Dry::Types['symbol'].enum(:permissive, :schema, :strict, :strict_with_defaults)
 
     # Sets or retrieves {#constructor} type as a symbol
     #
@@ -174,7 +172,7 @@ module Dry
     # @overload constructor_type
     #   Returns the constructor type for {Struct}
     #   @return [Symbol] (:strict)
-    defines :constructor_type, type: valid_constructor_types
+    defines :constructor_type, type: CONSTRUCTOR_TYPE
     constructor_type :permissive
 
     # @return [Dry::Equalizer]

--- a/lib/dry/struct.rb
+++ b/lib/dry/struct.rb
@@ -70,6 +70,10 @@ module Dry
     defines :schema
     schema EMPTY_HASH
 
+    def self.valid_constructor_types
+      Dry::Types['symbol'].enum(:permissive, :schema, :strict, :strict_with_defaults)
+    end
+
     # Sets or retrieves {#constructor} type as a symbol
     #
     # @note All examples below assume that you have defined {Struct} with
@@ -106,13 +110,6 @@ module Dry
     # 2. Input omits a key for a value that has a default
     # 3. Input contains nil for a value that specifies a default
     # 4. Input includes a key that was not specified in the schema
-    #
-    # @note Don’t use `:weak` and `:symbolized` as {#constructor_type},
-    #   and instead use [`dry-validation`][] to process and validate
-    #   attributes, otherwise your struct will behave as a data validator
-    #   which raises exceptions on invalid input (assuming your attributes
-    #   types are strict)
-    #   [`dry-validation`]: https://github.com/dry-rb/dry-validation
     #
     # @example `:permissive` constructor
     #   class User < Dry::Struct
@@ -177,7 +174,7 @@ module Dry
     # @overload constructor_type
     #   Returns the constructor type for {Struct}
     #   @return [Symbol] (:strict)
-    defines :constructor_type
+    defines :constructor_type, type: valid_constructor_types
     constructor_type :permissive
 
     # @return [Dry::Equalizer]

--- a/spec/dry/struct_spec.rb
+++ b/spec/dry/struct_spec.rb
@@ -265,6 +265,14 @@ RSpec.describe Dry::Struct do
     end
   end
 
+  describe 'defining constructor_type with weak or symbolized' do
+    it 'raises InvalidClassAttributeValue' do
+      expect{
+        class Test::Parent < Dry::Struct; constructor_type(:weak); end
+      }.to raise_error(Dry::Core::InvalidClassAttributeValue)
+    end
+  end
+
   describe 'with a blank schema' do
     it 'works for blank structs' do
       class Test::Foo < Dry::Struct; end

--- a/spec/shared/struct.rb
+++ b/spec/shared/struct.rb
@@ -89,7 +89,7 @@ RSpec.shared_examples_for Dry::Struct do
   end
 
   context 'class interface' do
-    it_behaves_like Dry::Types::Definition, from_dry_struct: true
+    it_behaves_like Dry::Types::Definition
 
     describe '.|' do
       let(:sum_type) { type | Dry::Types['strict.nil'] }

--- a/spec/shared/struct.rb
+++ b/spec/shared/struct.rb
@@ -89,7 +89,7 @@ RSpec.shared_examples_for Dry::Struct do
   end
 
   context 'class interface' do
-    it_behaves_like Dry::Types::Definition
+    it_behaves_like Dry::Types::Definition, from_dry_struct: true
 
     describe '.|' do
       let(:sum_type) { type | Dry::Types['strict.nil'] }


### PR DESCRIPTION
@solnic @flash-gordon 

This restricts the use of weak and symbolize in the constrictor type with the use of the latest `dry-core` release

Happens that with the latest version of `dry-types` some specs changed the location and one of them it was failing https://github.com/dry-rb/dry-types/blob/master/lib/dry/types/spec/types.rb#L81. This test is heavily used in `dry-types` so I thought to remove it was not an option, so I came with a little hackey solution 😄 

Hope this change helps.


