### PR TITLE
Support nested structs by passing a block to Dry::Struct.attribute

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,11 @@ If you found a bug, report an issue and describe what's the expected behavior ve
 
 ## Reporting feature requests
 
-Report a feature request **only after discussing it first on [discuss.dry-rb.org](https://discuss.dry-rb.org)** where it was accepted. Please provide a concise description of the feature, don't link to a discussion thread, and instead summarize what was discussed.
+Report a feature request **only after discourseing it first on [discourse.dry-rb.org](https://discourse.dry-rb.org)** where it was accepted. Please provide a concise description of the feature, don't link to a discourseion thread, and instead summarize what was discourseed.
 
 ## Reporting questions, support requests, ideas, concerns etc.
 
-**PLEASE DON'T** - use [discuss.dry-rb.org](http://discuss.dry-rb.org) instead.
+**PLEASE DON'T** - use [discourse.dry-rb.org](https://discourse.dry-rb.org) instead.
 
 # Pull Request Guidelines
 
@@ -26,4 +26,4 @@ Other requirements:
 
 # Asking for help
 
-If these guidelines aren't helpful, and you're stuck, please post a message on [discuss.dry-rb.org](https://discuss.dry-rb.org).
+If these guidelines aren't helpful, and you're stuck, please post a message on [discourse.dry-rb.org](https://discourse.dry-rb.org).

--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -97,10 +97,8 @@ module Dry
 
       # @param [Dry::Struct] superclass the superclass of the nested struct
       # @yield the body of the nested struct
-      def build_nested_type(superclass, &body)
-        Class.new(superclass).tap do |struct|
-          struct.instance_eval(&body)
-        end
+      def build_nested_type(superclass, &block)
+        Class.new(superclass, &block)
       end
       private :build_nested_type
 

--- a/spec/dry/struct_spec.rb
+++ b/spec/dry/struct_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe Dry::Struct do
 
   before do
     module Test
+      class BaseAddress < Dry::Struct
+        attribute :street, 'strict.string'
+      end
+
       class Address < Dry::Struct
         attribute :city, 'strict.string'
         attribute :zipcode, 'coercible.string'
@@ -163,12 +167,63 @@ RSpec.describe Dry::Struct do
       expect(user.address.zipcode).to eql('123')
     end
 
-    it 'defines attributes for the constructor' do
-      user = user_type[
-        name: :Jane, age: '21', address: { city: 'NYC', zipcode: 123 }
-      ]
+    context 'when given a pre-defined nested type' do
+      it 'defines attributes for the constructor' do
+        user = user_type[
+          name: :Jane, age: '21', address: { city: 'NYC', zipcode: 123 }
+        ]
 
-      assert_valid_struct(user)
+        assert_valid_struct(user)
+      end
+    end
+
+    context 'when given a block-style nested type' do
+      context 'with no superclass type' do
+        let(:user_type) do
+          Class.new(Dry::Struct) do
+            attribute :name, 'coercible.string'
+            attribute :age, 'coercible.int'
+            attribute :address do
+              attribute :city, 'strict.string'
+              attribute :zipcode, 'coercible.string'
+            end
+          end
+        end
+
+        it 'defines attributes for the constructor' do
+          user = user_type[
+            name: :Jane, age: '21', address: { city: 'NYC', zipcode: 123 }
+          ]
+
+          assert_valid_struct(user)
+        end
+      end
+
+      context 'with a superclass type' do
+        let(:user_type) do
+          Class.new(Dry::Struct) do
+            attribute :name, 'coercible.string'
+            attribute :age, 'coercible.int'
+            attribute :address, Test::BaseAddress do
+              attribute :city, 'strict.string'
+              attribute :zipcode, 'coercible.string'
+            end
+          end
+        end
+
+        it 'defines attributes for the constructor' do
+          user = user_type[
+            name: :Jane, age: '21', address: {
+              street: '123 Fake Street',
+              city: 'NYC',
+              zipcode: 123
+            }
+          ]
+
+          assert_valid_struct(user)
+          expect(user.address.street).to eq('123 Fake Street')
+        end
+      end
     end
 
     it 'ignores unknown keys' do
@@ -189,12 +244,26 @@ RSpec.describe Dry::Struct do
       expect(user.root).to be(true)
     end
 
-    it 'raises error when type is missing' do
-      expect {
-        class Test::Foo < Dry::Struct
-          attribute :bar
-        end
-      }.to raise_error(ArgumentError)
+    context 'when no nested attribute block given' do
+      it 'raises error when type is missing' do
+        expect {
+          class Test::Foo < Dry::Struct
+            attribute :bar
+          end
+        }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when nested attribute block given' do
+      it 'does not raise error when type is missing' do
+        expect {
+          class Test::Foo < Dry::Struct
+            attribute :bar do
+              attribute :foo, 'strict.string'
+            end
+          end
+        }.to_not raise_error
+      end
     end
 
     it 'raises error when attribute is defined twice' do


### PR DESCRIPTION
As discussed in https://github.com/dry-rb/dry-struct/issues/2

### Examples

```ruby
module Types
  include Dry::Types.module
end

user_class = Class.new(Dry::Struct) do
  attribute :name, Types::Coercible::String
  attribute :age, Types::Coercible::Int
  attribute :address do
    attribute :city, Types::Coercible::String
    attribute :zipcode, Types::Coercible::String
  end
end

user = user_class.new(
  name: :Jane,
  age: '21',
  address: {
    city: 'NYC',
    zipcode: 123
  }
)
# => #<#<Class:0x000056302e515c48> name="Jane" age=21 address=#<#<Class:0x000056302e514118> city="NYC" zipcode="123">>
user.address.city
# => "NYC"
user.address.zipcode
# => "123"
```

You can also pass a superclass type, this will be used as the superclass of the nested type that is built, i.e.

```ruby
module Types
  include Dry::Types.module
end

class BaseAddress < Dry::Struct
  attribute :street, 'strict.string'
end

user_class = Class.new(Dry::Struct) do
  attribute :name, Types::Coercible::String
  attribute :age, Types::Coercible::Int
  attribute :address, BaseAddress do
    attribute :city, Types::Coercible::String
    attribute :zipcode, Types::Coercible::String
  end
end

user = user_class.new(
  name: :Jane,
  age: '21',
  address: {
  street: '123 Fake Street',
    city: 'NYC',
    zipcode: 123
  }
)
# => #<#<Class:0x0000559a6dd19770> name="Jane" age=21 address=#<#<Class:0x0000559a6dd13118> street="123 Fake Street" city="NYC" zipcode="123">>
user.address.street
# => "123 Fake Street"
```

This is useful for both scenarios where you have a custom type that you would like to extend for a one-off use-case as well as defining a base type to set the `constructor_type`

CC: @solnic @timriley @flash-gordon @GustavoCaso 