### PR TITLE
Fix schema ignoring superclass's schema changes

### DIFF
--- a/lib/dry/struct.rb
+++ b/lib/dry/struct.rb
@@ -67,8 +67,15 @@ module Dry
     input Types['coercible.hash']
 
     # @return [Hash{Symbol => Dry::Types::Definition, Dry::Struct}]
-    defines :schema
-    schema EMPTY_HASH
+    def self.schema(value = Undefined)
+      @schema ||= EMPTY_HASH
+
+      if value == Undefined
+        super_schema.merge @schema
+      else
+        @schema = value
+      end
+    end
 
     CONSTRUCTOR_TYPE = Dry::Types['symbol'].enum(:permissive, :schema, :strict, :strict_with_defaults)
 

--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -79,11 +79,18 @@ module Dry
       # @raise [RepeatedAttributeError] when trying to define attribute with the
       #   same name as previously defined one
       def check_schema_duplication(new_schema)
-        shared_keys = new_schema.keys & (schema.keys - superclass.schema.keys)
+        self_unique_keys = schema.keys - super_schema.keys
+        conflicting_keys = new_schema.keys & self_unique_keys
 
-        raise RepeatedAttributeError, shared_keys.first if shared_keys.any?
+        raise RepeatedAttributeError, conflicting_keys.first if conflicting_keys.any?
       end
       private :check_schema_duplication
+
+      # @return [Hash{Symbol => Dry::Types::Definition, Dry::Struct}]
+      def super_schema
+        defined?(superclass.schema) ? superclass.schema : EMPTY_HASH
+      end
+      private :super_schema
 
       # @param [Hash{Symbol => Object},Dry::Struct] attributes
       # @raise [Struct::Error] if the given attributes don't conform {#schema}

--- a/spec/dry/struct_spec.rb
+++ b/spec/dry/struct_spec.rb
@@ -263,6 +263,35 @@ RSpec.describe Dry::Struct do
       class Test::Child < Test::Parent; end
       expect(Test::Child.constructor_type).to eql(:schema)
     end
+
+    it 'child class inherits schema' do
+      class Test::ParentSchema < Dry::Struct
+        attribute :bar, 'string'
+      end
+
+      Test::ChildSchema = Class.new(Test::ParentSchema)
+
+      [Test::ParentSchema,
+       Test::ChildSchema].each do |klass|
+        expect(klass.schema[:bar]).to eq 'string'
+        expect(klass.instance_methods).to include :bar
+      end
+    end
+
+    context 'when parent schema is changed after inheritance' do
+      it 'child class inherits changed schema' do
+        Test::ParentSchemaChange = Class.new(Dry::Struct)
+        Test::ChildSchemaChange  = Class.new(Test::ParentSchemaChange)
+
+        Test::ParentSchemaChange.attribute :foo, 'string'
+
+        [Test::ParentSchemaChange,
+         Test::ChildSchemaChange].each do |klass|
+          expect(klass.schema[:foo]).to eq 'string'
+          expect(klass.instance_methods).to include :foo
+        end
+      end
+    end
   end
 
   describe 'defining constructor_type with weak or symbolized' do


### PR DESCRIPTION
This is a fix for issue #51

```ruby
Parent = Class.new(Dry::Struct)
Child  = Class.new(Parent)

Parent.attribute :foo, 'string'
```

## Currently
`Dry::Core::ClassAttributes#defines` is used in `Dry::Struct` to set up `schema`. A subclass gets its schema from the superclass *only* at the time of inheritance.
```ruby
Child.schema[:foo] # => nil
```

## Proposed
Define `schema` directly on `Dry::Struct`. Have it check for a superclass's schema.
```ruby
Child.schema[:foo] # => 'string'
```

This will mean that there is no module (it's currently an anonymous module) in the lookup chain. I can also move the new `schema` definition into `Dry::Struct::ClassInterface` if that's preferable.