### PR TITLE
Replace constructor_type with types/keys transformations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'dry-types', git: 'https://github.com/dry-rb/dry-types'
+gem 'dry-types', git: 'https://github.com/dry-rb/dry-types', branch: 'new-schema-api'
 
 group :test do
   gem 'codeclimate-test-reporter', platform: :mri, require: false

--- a/lib/dry/struct.rb
+++ b/lib/dry/struct.rb
@@ -87,10 +87,6 @@ module Dry
     defines :input
     input Types['coercible.hash'].schema(EMPTY_HASH)
 
-    # @return [Hash{Symbol => Dry::Types::Definition, Dry::Struct}]
-    defines :schema
-    schema EMPTY_HASH
-
     # @return [Dry::Equalizer]
     defines :equalizer
 

--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -93,7 +93,7 @@ module Dry
         check_schema_duplication(new_schema)
 
         schema schema.merge(new_schema)
-        input Types['coercible.hash'].public_send(constructor_type, schema)
+        input input.schema(new_schema)
 
         new_schema.each_key do |key|
           attr_reader(key) unless instance_methods.include?(key)
@@ -133,7 +133,6 @@ module Dry
 
       # @param [Hash{Symbol => Object},Dry::Struct] attributes
       # @raise [Struct::Error] if the given attributes don't conform {#schema}
-      #   with given {#constructor_type}
       def new(attributes = default_attributes)
         if attributes.instance_of?(self)
           attributes

--- a/spec/dry/struct_spec.rb
+++ b/spec/dry/struct_spec.rb
@@ -36,13 +36,6 @@ RSpec.describe Dry::Struct do
   shared_examples_for 'typical constructor' do
     it 'raises StructError when attribute constructor failed' do
       expect {
-        construct_user(age: {})
-      }.to raise_error(
-        Dry::Struct::Error,
-        '[Test::User.new] :name is missing in Hash input'
-      )
-
-      expect {
         construct_user(name: :Jane, age: '21', address: nil)
       }.to raise_error(
         Dry::Struct::Error,
@@ -356,18 +349,10 @@ RSpec.describe Dry::Struct do
   end
 
   describe 'when inheriting a struct from another struct' do
-    it 'also inherits the constructor_type' do
-      class Test::Parent < Dry::Struct; constructor_type(:schema); end
+    it 'also inherits the schema' do
+      class Test::Parent < Dry::Struct; input input.strict; end
       class Test::Child < Test::Parent; end
-      expect(Test::Child.constructor_type).to eql(:schema)
-    end
-  end
-
-  describe 'defining constructor_type with weak or symbolized' do
-    it 'raises InvalidClassAttributeValue' do
-      expect{
-        class Test::Parent < Dry::Struct; constructor_type(:weak); end
-      }.to raise_error(Dry::Core::InvalidClassAttributeValue)
+      expect(Test::Child.input).to be_strict
     end
   end
 
@@ -378,11 +363,9 @@ RSpec.describe Dry::Struct do
     end
   end
 
-  describe 'with a non-strict schema' do
+  describe 'default values' do
     subject(:struct) do
       Class.new(Dry::Struct) do
-        constructor_type(:schema)
-
         attribute :name, Dry::Types['strict.string'].default('Jane')
         attribute :age, Dry::Types['strict.int']
         attribute :admin, Dry::Types['strict.bool'].default(true)

--- a/spec/dry/struct_spec.rb
+++ b/spec/dry/struct_spec.rb
@@ -43,15 +43,6 @@ RSpec.describe Dry::Struct do
       )
     end
 
-    it 'raise ArgumentError when the attributes types are strings' do
-      expect {
-        user_type.new
-      }.to raise_error(
-        ArgumentError,
-        'Invaild argument for name, age'
-      )
-    end
-
     it 'passes through values when they are structs already' do
       address = Test::Address.new(city: 'NYC', zipcode: '312')
       user = construct_user(name: 'Jane', age: 21, address: address)

--- a/spec/dry_spec.rb
+++ b/spec/dry_spec.rb
@@ -4,8 +4,7 @@ RSpec.describe Dry do
     context 'constructor types' do
       %i[permissive schema strict strict_with_defaults].each do |constructor|
         it "returns a struct with constructor type #{constructor}" do
-          struct_klass = Dry.Struct(constructor, name: 'strict.string')
-          expect(struct_klass.constructor_type).to eq constructor
+          struct_klass = Dry.Struct(name: 'strict.string')
 
           struct = struct_klass.new(name: 'Test')
           expect(struct.__attributes__).to eq(name: 'Test')
@@ -17,7 +16,7 @@ RSpec.describe Dry do
       before do
         module Test
           Library = Dry.Struct do
-            constructor_type :strict
+            input input.strict
 
             attribute :library, 'strict.string'
             attribute :language, 'strict.string'

--- a/spec/shared/struct.rb
+++ b/spec/shared/struct.rb
@@ -118,7 +118,7 @@ RSpec.shared_examples_for Dry::Struct do
 
       it 'returns Default type' do
         expect(default_type).to be_instance_of(Dry::Types::Default)
-        expect(default_type[nil]).to eql(type[jane])
+        expect(default_type[]).to eql(type[jane])
       end
     end
 

--- a/spec/shared/struct.rb
+++ b/spec/shared/struct.rb
@@ -175,6 +175,41 @@ RSpec.shared_examples_for Dry::Struct do
         expect(type.meta).to eql({})
       end
     end
+
+    describe '.transform_types' do
+      it 'adds a type transformation' do
+        type.transform_types { |t| t.meta(tranformed: true) }
+        type.attribute(:city, Dry::Types["strict.string"])
+        expect(type.schema[:city].meta).to eql(tranformed: true)
+      end
+
+      it 'accepts a proc' do
+        type.transform_types(-> t { t.meta(tranformed: true) })
+        type.attribute(:city, Dry::Types["strict.string"])
+        expect(type.schema[:city].meta).to eql(tranformed: true)
+      end
+    end
+
+    describe '.transform_keys' do
+      let(:jane_str) do
+        {
+          'name' => :Jane,
+          'age' => '21',
+          'root' => true,
+          'address' => { city: 'NYC', zipcode: 123 }
+        }
+      end
+
+      it 'adds a key tranformation' do
+        type.transform_keys(&:to_sym)
+        expect(type.(jane_str)).to eql(type.(jane))
+      end
+
+      it 'accepts a proc' do
+        type.transform_keys(:to_sym.to_proc)
+        expect(type.(jane_str)).to eql(type.(jane))
+      end
+    end
   end
 
   it 'registered without wrapping' do


### PR DESCRIPTION
This removes `constructor_type` in favor of these two methods:

1. `Struct.transform_types`—transforms all _new_ attribute types with an arbitrary block (uses `Dry::Types::Schema#with_type_transform`).
1. `Struct.transform_keys`—transforms input keys with a block (uses `Dry::Types::Hash#with_key_transform`).

See https://github.com/dry-rb/dry-types/pull/231

For unknown keys it is possible to make the underlying schema _strict_:

```ruby
class Book < Dry::Struct
  input input.strict

  attribute :title, Types::Strict::String
end

Book.new(title: "The Old Man and the Sea", foo: :bar) 
# => Dry::Struct::Error ([Book.new] unexpected keys [:foo] in Hash input)
```

You always can create a base class for strict structs:

```ruby
StrictStruct = Class.new(Dry::Struct) { input input.strict }
```

Also, individual attributes can be omitted with adding `omittable: true` to theirs meta:

```ruby
class Book < Dry::Struct
  attribute :title, Types::Strict::String
  attribute :year, Types::Strict::Int.meta(omittable: true)
end
Book.new(title: "The Old Man and the Sea")
# => #<Book title="The Old Man and the Sea" year=nil>
```

You can combine it with `tranform_types` for getting a struct not raising an error on missing keys:
```ruby
class Book < Dry::Struct
  transform_types { |t| t.meta(omittable: true) }

  attribute :title, Types::Strict::String
  attribute :year, Types::Strict::Int
end
Book.new # => #<Book title=nil year=nil>
```

P.S. Note that in the new version of `dry-types` default types in hash schema are only used/evaluated when a key is missing, not when the value is `nil`:

```ruby
class Book < Dry::Struct
  attribute :title, Types::Strict::String
  attribute :year, Types::Strict::Int.default { Time.now.year }
end
Book.new(title: "The Old Man and the Sea")
# => #<Book title="The Old Man and the Sea" year=2018>
# BUT
Book.new(title: "The Old Man and the Sea", year: nil)
# => Dry::Struct::Error ([Book.new] nil (NilClass) has invalid type for :year violates constraints (type?(Integer, nil) failed))
```

If you want to evaluate default value on `nil`, use `.constructor`:
```ruby
class Book < Dry::Struct
  attribute :title, Types::Strict::String
  attribute :year, Types::Strict::Int.
                     default { Time.now.year }.
                     constructor { |v| v.nil? ? Dry::Types::Undefined : v }
end
# => #<Book title="The Old Man and the Sea" year=2018>
```

`Undefined` is treated as a missing value, that's how it works internally.

Remember, you can automate "constructing" with `transform_types`:
```ruby
class DefaultOnNilStruct < Dry::Stuct
  nil_2_undef = -> v { v.nil? ? Dry::Types::Undefined : v }
  transform_types { |t| t.default? ? t.constructor(nil_2_undef) : t }
end

class Book < DefaultOnNilStruct
  attribute :title, Types::Strict::String
  attribute :year, Types::Strict::Int.default { Time.now.year }
end
# => #<Book title="The Old Man and the Sea" year=2018>
```