### PR TITLE
Store values within a signle ivar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ before_install:
 after_success:
   - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
 rvm:
-  - 2.2.9
   - 2.3.6
   - 2.4.3
   - 2.5.0

--- a/dry-struct.gemspec
+++ b/dry-struct.gemspec
@@ -26,6 +26,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = ">= 2.3.0"
+
   spec.add_runtime_dependency 'dry-equalizer', '~> 0.2'
   spec.add_runtime_dependency 'dry-types', '~> 0.12', '>= 0.12.2'
   spec.add_runtime_dependency 'dry-core', '~> 0.4', '>= 0.4.1'

--- a/spec/dry/struct_spec.rb
+++ b/spec/dry/struct_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe Dry::Struct do
     it "doesn't define readers if methods are present" do
       class Test::Foo < Dry::Struct
         def age
-          "#{ @age } years old"
+          "#{ @attributes[:age] } years old"
         end
       end
 


### PR DESCRIPTION
Previously, we stored values in separate instance variables, this changes behavior in favor of using a single ivar. Even for a struct of 3 attributes, it adds roughly 12% to initialization speed.
```
Warming up --------------------------------------
           benchmark     8.476k i/100ms
Calculating -------------------------------------
           benchmark     86.125k (± 5.9%) i/s -    432.276k in   5.038505s

Warming up --------------------------------------
           benchmark     9.449k i/100ms
Calculating -------------------------------------
           benchmark     97.353k (± 5.8%) i/s -    491.348k in   5.067257s
```

For 15 attributes it's ~20%:

```
Warming up --------------------------------------
           benchmark     1.990k i/100ms
Calculating -------------------------------------
           benchmark     20.737k (± 4.7%) i/s -    103.480k in   5.001104s

Warming up --------------------------------------
           benchmark     2.377k i/100ms
Calculating -------------------------------------
           benchmark     24.323k (± 4.1%) i/s -    123.604k in   5.090141s
```