### PR TITLE
Add missing require for bin/console

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -3,4 +3,10 @@
 require 'bundler/setup'
 require 'dry/struct'
 
+require 'irb'
+
+module Types
+  include Dry::Types.module
+end
+
 binding.irb


### PR DESCRIPTION
@flash-gordon I was playing with it and notice `bin/console` was not working