### PR TITLE
yard typo

### DIFF
--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -220,7 +220,7 @@ module Dry
       alias_method :[], :call
 
       # @param [#call,nil] constructor
-      # @param [Hash] options
+      # @param [Hash] _options
       # @param [#call,nil] block
       # @return [Dry::Struct::Constructor]
       def constructor(constructor = nil, **_options, &block)


### PR DESCRIPTION
Apparently the argument is unused but the yard doc states that it is.

https://app.coditsu.io/dry-rb/builds/validations/94eda77d-2787-478e-9381-b8292aa3d8aa/offenses?q[offense_name_cont]=UnknownParameterName