### PR TITLE
build default attributes when calling #new and #call without arguments

### DIFF
--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -198,7 +198,7 @@ module Dry
 
       # @param [Hash{Symbol => Object},Dry::Struct] attributes
       # @raise [Struct::Error] if the given attributes don't conform {#schema}
-      def new(attributes = EMPTY_HASH)
+      def new(attributes = default_attributes)
         if attributes.instance_of?(self)
           attributes
         else
@@ -213,7 +213,7 @@ module Dry
       #
       # @param [Hash{Symbol => Object},Dry::Struct] attributes
       # @return [Dry::Struct]
-      def call(attributes = EMPTY_HASH)
+      def call(attributes = default_attributes)
         return attributes if attributes.is_a?(self)
         new(attributes)
       end
@@ -341,6 +341,17 @@ module Dry
         @struct_builder ||= StructBuilder.new(self).freeze
       end
       private :struct_builder
+
+      # Retrieves default attributes from defined {.schema}.
+      # Used in a {Struct} constructor if no attributes provided to {.new}
+      #
+      # @return [Hash{Symbol => Object}]
+      def default_attributes(default_schema = schema)
+        default_schema.each_with_object({}) do |(name, type), result|
+          result[name] = default_attributes(type.schema) if type.respond_to?(:schema)
+        end
+      end
+      private :default_attributes
     end
   end
 end

--- a/spec/dry/struct_spec.rb
+++ b/spec/dry/struct_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Dry::Struct do
     end
 
     context 'with default' do
-      it 'resolves missing missing values with defaults' do
+      it 'resolves missing values with defaults' do
         struct = Class.new(Dry::Struct) do
           attribute :name, Dry::Types['strict.string'].default('Jane')
           attribute :admin, Dry::Types['strict.bool'].default(true)
@@ -69,6 +69,28 @@ RSpec.describe Dry::Struct do
         struct = Class.new(Dry::Struct) do
           attribute :name, Dry::Types['strict.string'].default('Jane')
           attribute :age, Dry::Types['strict.integer']
+        end
+
+        expect { struct.new }.to raise_error(Dry::Struct::Error, /:age is missing in Hash input/)
+      end
+
+      it "resolves missing values for nested attributes" do
+        struct = Class.new(Dry::Struct) do
+          attribute :kid do
+            attribute :age, Dry::Types['strict.integer'].default(16)
+          end
+        end
+
+        expect(struct.new.to_h).
+          to eql({kid: {age: 16}})
+      end
+
+      it "doesn't tolerate missing required keys for nested attributes" do
+        struct = Class.new(Dry::Struct) do
+          attribute :kid do
+            attribute :name, Dry::Types['strict.string'].default('Jane')
+            attribute :age, Dry::Types['strict.integer']
+          end
         end
 
         expect { struct.new }.to raise_error(Dry::Struct::Error, /:age is missing in Hash input/)


### PR DESCRIPTION
@flash-gordon @solnic @AMHOL 

Way to infer default values for nested attributes when calling `new` and `call`.

This will simplify a lot `dry-configurable` https://github.com/dry-rb/dry-configurable/pull/48 avoiding the need for creating the default values 