### PR TITLE
default_attributes add cases for hash type and array type

### DIFF
--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -348,10 +348,38 @@ module Dry
       # @return [Hash{Symbol => Object}]
       def default_attributes(default_schema = schema)
         default_schema.each_with_object({}) do |(name, type), result|
-          result[name] = default_attributes(type.schema) if type.respond_to?(:schema)
+          if hash_type?(type)
+            result[name] = {}
+          elsif array_type?(type)
+            result[name] = []
+          elsif type.respond_to?(:schema)
+            result[name] = default_attributes(type.schema)
+          end
         end
       end
       private :default_attributes
+
+      # check if current type is a Dry::Types::Hash
+      #
+      # @return [Boolean]
+      def hash_type?(type)
+        type?(type, Hash)
+      end
+      private :hash_type?
+
+      # check if current type is a Dry::Types::Array
+      #
+      # @return [Boolean]
+      def array_type?(type)
+        type?(type, Array)
+      end
+      private :array_type?
+
+      # @return [Boolean]
+      def type?(type, klass)
+        type.is_a?(Types::Type) && type.respond_to?(:primitive) && type.primitive.equal?(klass)
+      end
+      private :type?
     end
   end
 end


### PR DESCRIPTION
@flash-gordon while working on the new internals of `dry-configurable` I notice that `default_attributes` was failing if the type of setting was a `Hash`, because both `Dry::Struct` and `Types::Hash` both have `schema` method but with different arity

I added cases for `Array` and `Hash`

At first, I was doing for the hash case: 
```ruby
result[name] = deafult_attributes(type.member_types)
```
But the result was the same.
As well for the `array` case:
```ruby
result[name] = default_attributes(type.member)
```
but this was failing because it was returning a `hash` instead of an `array`

As for the style of the code, we could remove some of the duplications making the method look like this:

```ruby
def default_attributes(default_schema = schema)
  default_schema.each_with_object({}) do |(name, type), result|
    value = if hash_type?(type)
                    {}
                 elsif array_type?(type)
                    []
                  elsif type.respond_to?(:schema)
                    default_attributes(type.schema)
                  end

      result[name] = value if value
    end
end
```

Whatever works best for you. 😄 