### PR TITLE
Update version of dry-types dependency

### DIFF
--- a/dry-struct.gemspec
+++ b/dry-struct.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'dry-equalizer', '~> 0.2'
-  spec.add_runtime_dependency 'dry-types', '>= 1.0.0.beta', '< 2'
+  spec.add_runtime_dependency 'dry-types', '>= 0.13', '< 2'
   spec.add_runtime_dependency 'dry-core', '~> 0.4', '>= 0.4.3'
   spec.add_runtime_dependency 'ice_nine', '~> 0.11'
 

--- a/dry-struct.gemspec
+++ b/dry-struct.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'dry-equalizer', '~> 0.2'
+  spec.add_runtime_dependency 'dry-inflector', '~> 0.1'
   spec.add_runtime_dependency 'dry-types', '>= 0.13', '< 2'
   spec.add_runtime_dependency 'dry-core', '~> 0.4', '>= 0.4.3'
   spec.add_runtime_dependency 'ice_nine', '~> 0.11'


### PR DESCRIPTION
Next release of dry-types gem switch to be 0.13 instead of 1.0.0.beta

https://github.com/dry-rb/dry-types/blob/master/lib/dry/types/version.rb
https://github.com/dry-rb/dry-types/blob/master/CHANGELOG.md