### PR TITLE
Fix unable to declare an attribute with same name of a constant outside struct class definition

### DIFF
--- a/lib/dry/struct/struct_builder.rb
+++ b/lib/dry/struct/struct_builder.rb
@@ -60,7 +60,7 @@ module Dry
         raise(
           Struct::Error,
           "Can't create nested attribute - `#{struct}::#{name}` already defined"
-        ) if struct.const_defined?(name)
+        ) if Object.const_defined?("#{struct.name}::#{name}")
       end
 
       def visit_constrained(node)


### PR DESCRIPTION
Fixes #91 