### PR TITLE
[Enhancement] Raise MissingAttributeError within block

### DIFF
--- a/lib/dry/struct.rb
+++ b/lib/dry/struct.rb
@@ -120,9 +120,7 @@ module Dry
     #   rom_n_roda[:title] #=> 'Web Development with ROM and Roda'
     #   rom_n_roda[:subtitle] #=> nil
     def [](name)
-      @attributes.fetch(name)
-    rescue KeyError
-      raise MissingAttributeError.new(name)
+      @attributes.fetch(name) { raise MissingAttributeError.new(name) }
     end
 
     # Converts the {Dry::Struct} to a hash with keys representing


### PR DESCRIPTION
This request avoids the unnecessary `rescue KeyError` within  [`Dry::Struct#[]`](https://github.com/noname00000123/dry-struct/blob/1bc33d50c7b4615a328ab9f496709e6f37c82f62/lib/dry/struct.rb#L122)  raising within the block passed to `@attributes.fetch(name)` instead; ~300x faster than the current implementation. 

```ruby
  require 'benchmark/ips'

  def self.implementation
    {}.fetch(:key)
  rescue KeyError
    1 # raise(::StandardError, :key)
  end

  def self.revision
    {}.fetch(:key) { 1 } # { raise(::StandardError, :key) }
  end

  # Warming up --------------------------------------
  #       implementation     2.399k i/100ms
  #             revision   335.817k i/100ms
  # Calculating -------------------------------------
  #       implementation     25.164k (± 2.3%) i/s -    127.147k in   5.055450s
  #             revision      7.456M (± 1.3%) i/s -     37.276M in   5.000437s
  #
  # Comparison:
  #             revision:  7455830.2 i/s
  #       implementation:    25164.3 i/s - 296.29x  slower
  Benchmark.ips do |x |
    x.report('implementation') { implementation() }

    x.report('revision') { revision() }

    x.compare!
  end
```
