### PR TITLE
Restrict constant lookup

### DIFF
--- a/lib/dry/struct/struct_builder.rb
+++ b/lib/dry/struct/struct_builder.rb
@@ -60,7 +60,7 @@ module Dry
         raise(
           Struct::Error,
           "Can't create nested attribute - `#{struct}::#{name}` already defined"
-        ) if struct.const_defined?(name)
+        ) if struct.const_defined?(name, false)
       end
 
       def visit_constrained(node)

--- a/spec/dry/struct/attribute_dsl/nested_struct_spec.rb
+++ b/spec/dry/struct/attribute_dsl/nested_struct_spec.rb
@@ -76,7 +76,15 @@ RSpec.describe Dry::Struct, method: '.attribute' do
       end
     end
 
-    context 'when the nested type is not already defined' do
+    context 'when the nested type is not defined' do
+      let(:struct) { Class.new(Dry::Struct) }
+
+      it 'should check constant existence within class scope only' do
+        expect { struct.attribute(:test) { attribute(:abc, 'string') } }.not_to raise_error
+      end
+    end
+
+    context 'when the nested type is already defined' do
       before do
         module Test
           module AlreadyDefined


### PR DESCRIPTION
```ruby
  # When a constant with a name matching nested attribute :data exists
  Data = Module.new

  module Namespace
    class Struct < Dry::Struct
      attribute(:data) do
        attribute(:num, Dry::Types::Integer)
      end
    end
  end # => Dry::Struct::Error
```

`Dry::Struct::Error: Can't create nested attribute - Namespace::Struct::Data already defined`

This pr restricts constant lookup to class scope [`Dry::Struct::StructBuilder#check_name`](https://github.com/dry-rb/dry-struct/blob/master/lib/dry/struct/struct_builder.rb#L63)