### PR TITLE
Add DSL for defining omittable keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@
 /pkg/
 /spec/reports/
 /tmp/
+*.log
 
 .DS_Store

--- a/spec/dry/struct/attribute_dsl/definition_spec.rb
+++ b/spec/dry/struct/attribute_dsl/definition_spec.rb
@@ -187,4 +187,32 @@ RSpec.describe Dry::Struct, method: '.attribute' do
     struct = Test::Foo.new(age: 18)
     expect(struct.age).to eql("18 years old")
   end
+
+  context 'attribute?' do
+    it 'defines omittable keys' do
+      class Test::Foo < Dry::Struct
+        attribute  :foo, 'strict.string'
+        attribute? :bar, 'strict.string'
+      end
+
+      struct = Test::Foo.new(foo: 'value')
+      expect(struct.foo).to eql('value')
+      expect(struct.attributes).not_to have_key(:bar)
+      expect(Test::Foo.has_attribute?(:bar)).to be true
+    end
+
+    it 'defines omittable structs' do
+      class Test::Foo < Dry::Struct
+        attribute  :foo, 'strict.string'
+        attribute? :nested do
+          attribute :bar, 'strict.string'
+        end
+      end
+
+      struct = Test::Foo.new(foo: 'value')
+      expect(struct.foo).to eql('value')
+      expect(struct.attributes).not_to have_key(:nested)
+      expect(Test::Foo.has_attribute?(:nested)).to be true
+    end
+  end
 end

--- a/spec/shared/struct.rb
+++ b/spec/shared/struct.rb
@@ -145,7 +145,14 @@ RSpec.shared_examples_for Dry::Struct do
       end
     end
 
-    describe '.attribute?' do
+    describe '.has_attribute?' do
+      it 'checks if a struct has an attribute' do
+        expect(type.has_attribute?(:name)).to be true
+        expect(type.has_attribute?(:last_name)).to be false
+      end
+    end
+
+    describe '.attribute?', :suppress_deprecations do
       it 'checks if a struct has an attribute' do
         expect(type.attribute?(:name)).to be true
         expect(type.attribute?(:last_name)).to be false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,4 +76,11 @@ RSpec.configure do |config|
   end
 
   config.order = :random
+
+  config.around :each, :suppress_deprecations do |ex|
+    logger = Dry::Core::Deprecations.logger
+    Dry::Core::Deprecations.set_logger!(DryStructSpec::ROOT.join('log/deprecations.log'))
+    ex.run
+    Dry::Core::Deprecations.set_logger!(logger)
+  end
 end


### PR DESCRIPTION
This utilizes an already defined method called `Struct.attribute?`. It now shows a warning if you use it for checking key presence suggesting to use `Struct.has_attribute?` as a replacement.