### PR TITLE
Sync with schema updates from dry-types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,13 @@ sudo: required
 bundler_args: --without benchmarks tools
 script:
   - bundle exec rake spec
-before_install:
-  - gem update --system
 after_success:
   - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
 rvm:
-  - 2.2.10
-  - 2.3.8
   - 2.4.5
   - 2.5.3
-  - 2.6
-  - jruby-9.2.0.0
+  - 2.6.1
+  - jruby-9.2.6.0
 env:
   global:
     - COVERAGE=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,34 @@
+# to-be-released
+
+## Changed
+
+* [BREAKING] `Struct.input` was renamed `Struct.schema`, hence `Struct.schema` returns an instance of `Dry::Types::Hash::Schema` rather than a `Hash`. Schemas are also implementing `Enumerable` but they iterate over key types.
+  New API:
+  ```ruby
+  User.schema.each do |key|
+    puts "Key name: #{ key.name }"
+    puts "Key type: #{ key.type }"
+  end
+  ```
+  To get a type by its name use `.key`:
+  ```ruby
+  User.schema.key(:id) # => #<Dry::Types::Hash::Key ...>
+  ```
+* [BREAKING] `transform_types` now passes one argument to the block, an instance of the `Key` type. Combined with the new API from dry-types it simplifies declaring omittable keys:
+  ```ruby
+  class StructWithOptionalKeys < Dry::Struct
+    transform_types { |key| key.required(false) }
+    # or simply
+    transform_types(&:omittable)
+  end
+  ```
+* [BREAKING] Minimal supported Ruby version is 2.4
+
 # v0.6.0 2018-10-24
 
-## BREAKING CHANGES
+## Changed
 
-* `Struct.attribute?` in the old sense is deprecated, use `has_attribute?` as a replacement
+* [BREAKING] `Struct.attribute?` in the old sense is deprecated, use `has_attribute?` as a replacement
 
 ## Added
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gemspec
 
-gem 'dry-types', github: 'dry-rb/dry-types', branch: 'rework-schemas'
+gem 'dry-types', github: 'dry-rb/dry-types'
 
 group :test do
   gem 'codeclimate-test-reporter', platform: :mri, require: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,10 @@
 source 'https://rubygems.org'
 
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
+
 gemspec
 
-gem 'dry-types', git: 'https://github.com/dry-rb/dry-types'
-gem 'dry-inflector', git: 'https://github.com/dry-rb/dry-inflector'
+gem 'dry-types', github: 'dry-rb/dry-types', branch: 'rework-schemas'
 
 group :test do
   gem 'codeclimate-test-reporter', platform: :mri, require: false
@@ -12,8 +13,8 @@ group :test do
 end
 
 group :tools do
+  gem 'pry'
   gem 'pry-byebug', platform: :mri
-  gem 'pry', platform: :jruby
   gem 'mutant'
   gem 'mutant-rspec'
 end

--- a/dry-struct.gemspec
+++ b/dry-struct.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+  spec.required_ruby_version = ">= 2.4.0"
 
   spec.add_runtime_dependency 'dry-equalizer', '~> 0.2'
   spec.add_runtime_dependency 'dry-types', '~> 0.13'

--- a/dry-struct.gemspec
+++ b/dry-struct.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dry-core', '~> 0.4', '>= 0.4.3'
   spec.add_runtime_dependency 'ice_nine', '~> 0.11'
 
-  spec.add_development_dependency 'bundler', '~> 1.6'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 11.0'
   spec.add_development_dependency 'rspec', '~> 3.3'
   spec.add_development_dependency 'yard', '~> 0.9.5'

--- a/lib/dry/struct.rb
+++ b/lib/dry/struct.rb
@@ -90,8 +90,8 @@ module Dry
 
     # {Dry::Types::Hash::Schema} subclass with specific behaviour defined for
     # @return [Dry::Types::Hash::Schema]
-    defines :input
-    input Types['coercible.hash'].schema(EMPTY_HASH)
+    defines :schema
+    schema Types['coercible.hash'].schema(EMPTY_HASH)
 
     @meta = EMPTY_HASH
 
@@ -143,8 +143,8 @@ module Dry
     #   rom_n_roda.to_hash
     #     #=> {title: 'Web Development with ROM and Roda', subtitle: nil}
     def to_hash
-      self.class.schema.keys.each_with_object({}) do |key, result|
-        result[key] = Hashify[self[key]] if attributes.key?(key)
+      self.class.schema.each_with_object({}) do |key, result|
+        result[key.name] = Hashify[self[key.name]] if attributes.key?(key.name)
       end
     end
     alias_method :to_h, :to_hash

--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -152,7 +152,7 @@ module Dry
       def attributes(new_schema)
         check_schema_duplication(new_schema)
 
-        input input.schema(new_schema)
+        schema schema.schema(new_schema)
 
         new_schema.each_key do |key|
           next if instance_methods.include?(key)
@@ -183,10 +183,10 @@ module Dry
       #     attribute :title, Types::Strict::String
       #   end
       #
-      #   Book.schema[:title].meta # => { struct: :Book }
+      #   Book.schema.key(:title).meta # => { struct: :Book }
       #
       def transform_types(proc = nil, &block)
-        input input.with_type_transform(proc || block)
+        schema schema.with_type_transform(proc || block)
       end
 
       # Add an arbitrary transformation for input hash keys.
@@ -203,16 +203,18 @@ module Dry
       #   Book.new('title' => "The Old Man and the Sea")
       #   # => #<Book title="The Old Man and the Sea">
       def transform_keys(proc = nil, &block)
-        input input.with_key_transform(proc || block)
+        schema schema.with_key_transform(proc || block)
       end
 
       # @param [Hash{Symbol => Dry::Types::Definition, Dry::Struct}] new_schema
       # @raise [RepeatedAttributeError] when trying to define attribute with the
       #   same name as previously defined one
       def check_schema_duplication(new_schema)
-        shared_keys = new_schema.keys & (schema.keys - superclass.schema.keys)
+        overlapping_keys = new_schema.keys & (attribute_names - superclass.attribute_names)
 
-        raise RepeatedAttributeError, shared_keys.first if shared_keys.any?
+        if overlapping_keys.any?
+          raise RepeatedAttributeError, overlapping_keys.first
+        end
       end
       private :check_schema_duplication
 
@@ -222,7 +224,7 @@ module Dry
         if attributes.instance_of?(self)
           attributes
         else
-          super(input[attributes])
+          super(schema[attributes])
         end
       rescue Types::SchemaError, Types::MissingKeyError, Types::UnknownKeysError => error
         raise Struct::Error, "[#{self}.new] #{error}"
@@ -321,16 +323,11 @@ module Dry
         schema.key?(key)
       end
 
-      # @return [Hash{Symbol => Dry::Types::Definition, Dry::Struct}]
-      def schema
-        input.member_types
-      end
-
       # Gets the list of attribute names
       #
       # @return [Array<Symbol>]
       def attribute_names
-        @attribute_names ||= schema.keys
+        @attribute_names ||= schema.map(&:name)
       end
 
       # @return [{Symbol => Object}]
@@ -367,8 +364,8 @@ module Dry
       #
       # @return [Hash{Symbol => Object}]
       def default_attributes(default_schema = schema)
-        default_schema.each_with_object({}) do |(name, type), result|
-          result[name] = default_attributes(type.schema) if struct?(type)
+        default_schema.each_with_object({}) do |key, result|
+          result[key.name] = default_attributes(key.schema) if struct?(key.type)
         end
       end
       private :default_attributes

--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -129,7 +129,7 @@ module Dry
         else
           name, type = args
 
-          attribute(name, build_type(name, type, &block).meta(omittable: true))
+          attribute(:"#{ name }?", build_type(name, type, &block))
         end
       end
 

--- a/spec/dry/struct/attribute_dsl/definition_spec.rb
+++ b/spec/dry/struct/attribute_dsl/definition_spec.rb
@@ -199,6 +199,9 @@ RSpec.describe Dry::Struct, method: '.attribute' do
       expect(struct.foo).to eql('value')
       expect(struct.attributes).not_to have_key(:bar)
       expect(Test::Foo.has_attribute?(:bar)).to be true
+
+      struct = Test::Foo.new(foo: 'value', bar: 'another value')
+      expect(struct.bar).to eql('another value')
     end
 
     it 'defines omittable structs' do

--- a/spec/dry/struct/attribute_dsl/nested_array_spec.rb
+++ b/spec/dry/struct/attribute_dsl/nested_array_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Dry::Struct, method: '.attribute' do
             end
 
             it 'uses the given array type' do
-              expect(user_type.schema[:permissions]).
+              expect(user_type.schema.key(:permissions).type).
                 to eql(Dry::Types[array_type].of(Test::User::Permission))
             end
 
@@ -92,7 +92,7 @@ RSpec.describe Dry::Struct, method: '.attribute' do
         end
 
         it 'uses the given array type' do
-          expect(user_type.schema[:permissions]).
+          expect(user_type.schema.key(:permissions).type).
             to eql(Dry::Types['strict.array'].of(Test::User::Permission))
         end
       end

--- a/spec/dry/struct_spec.rb
+++ b/spec/dry/struct_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe Dry::Struct do
       it "returns hash with attributes but will not try fetching omittable keys if not set" do
         type = Class.new(Dry::Struct) do
           attribute :name, Dry::Types['string']
-          attribute :last_name, Dry::Types['string'].meta(omittable: true)
+          attribute :last_name, Dry::Types['string'].meta(required: false)
         end
 
         attributes = { name: 'John' }
@@ -251,7 +251,7 @@ RSpec.describe Dry::Struct do
       it "returns hash with attributes but will fetch omittable keys if set" do
         type = Class.new(Dry::Struct) do
           attribute :name, Dry::Types['string']
-          attribute :last_name, Dry::Types['string'].meta(omittable: true)
+          attribute :last_name, Dry::Types['string'].meta(required: false)
         end
 
         attributes = { name: 'John', last_name: 'Doe' }
@@ -260,7 +260,7 @@ RSpec.describe Dry::Struct do
 
       it "returns empty hash if all attributes are ommitable and no value is set" do
         type = Class.new(Dry::Struct) do
-          attribute :name, Dry::Types['string'].meta(omittable: true)
+          attribute :name, Dry::Types['string'].meta(required: false)
         end
 
         expect(type.new.to_hash).to eq ({})

--- a/spec/dry/struct_spec.rb
+++ b/spec/dry/struct_spec.rb
@@ -146,8 +146,7 @@ RSpec.describe Dry::Struct do
     it 'adds attributes to all descendants' do
       Test::User.attribute(:signed_on, Dry::Types['strict.time'])
 
-      expect(Test::SuperUser.schema).
-        to include(signed_on: Dry::Types['strict.time'])
+      expect(Test::SuperUser.schema.key(:signed_on).type).to eql(Dry::Types['strict.time'])
     end
 
     it "doesn't override already defined attributes accidentally" do
@@ -156,15 +155,15 @@ RSpec.describe Dry::Struct do
       Test::SuperUser.attribute(:role, admin)
       Test::User.attribute(:role, Dry::Types['strict.string'].enum('author', 'subscriber'))
 
-      expect(Test::SuperUser.schema[:role]).to be(admin)
+      expect(Test::SuperUser.schema.key(:role).type).to be(admin)
     end
   end
 
   describe 'when inheriting a struct from another struct' do
     it 'also inherits the schema' do
-      class Test::Parent < Dry::Struct; input input.strict; end
+      class Test::Parent < Dry::Struct; schema schema.strict; end
       class Test::Child < Test::Parent; end
-      expect(Test::Child.input).to be_strict
+      expect(Test::Child.schema).to be_strict
     end
   end
 

--- a/spec/dry_spec.rb
+++ b/spec/dry_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Dry do
       before do
         module Test
           Library = Dry.Struct do
-            input input.strict
+            schema schema.strict
 
             attribute :library, 'strict.string'
             attribute :language, 'strict.string'

--- a/spec/shared/struct.rb
+++ b/spec/shared/struct.rb
@@ -187,13 +187,13 @@ RSpec.shared_examples_for Dry::Struct do
       it 'adds a type transformation' do
         type.transform_types { |t| t.meta(tranformed: true) }
         type.attribute(:city, Dry::Types["strict.string"])
-        expect(type.schema[:city].meta).to eql(tranformed: true)
+        expect(type.schema.key(:city).type.meta).to eql(tranformed: true)
       end
 
       it 'accepts a proc' do
         type.transform_types(-> (t, _name) { t.meta(tranformed: true) })
         type.attribute(:city, Dry::Types["strict.string"])
-        expect(type.schema[:city].meta).to eql(tranformed: true)
+        expect(type.schema.key(:city).type.meta).to eql(tranformed: true)
       end
     end
 

--- a/spec/shared/struct.rb
+++ b/spec/shared/struct.rb
@@ -191,7 +191,7 @@ RSpec.shared_examples_for Dry::Struct do
       end
 
       it 'accepts a proc' do
-        type.transform_types(-> (t, _name) { t.meta(tranformed: true) })
+        type.transform_types(-> (key) { key.meta(tranformed: true) })
         type.attribute(:city, Dry::Types["strict.string"])
         expect(type.schema.key(:city).type.meta).to eql(tranformed: true)
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,6 +76,7 @@ RSpec.configure do |config|
   end
 
   config.order = :random
+  config.filter_run_when_matching :focus
 
   config.around :each, :suppress_deprecations do |ex|
     logger = Dry::Core::Deprecations.logger


### PR DESCRIPTION
See https://github.com/dry-rb/dry-types/pull/286

This also replaces Struct.input with Struct.schema since now schema is not an abstract thing anymore. In ROM we may want to use something like `schema schema.constructor(&:itself)` to make struct constructors work faster when no type checks needed.