### PR TITLE
CI: Use jruby-9.2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
   - 2.4.5
   - 2.5.5
   - 2.6.2
-  - jruby-9.2.6.0
+  - jruby-9.2.7.0
   - truffleruby
 env:
   global:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.7.0**.

[JRuby 9.2.7.0 release blog post](https://www.jruby.org/2019/04/09/jruby-9-2-7-0.html)