### PR TITLE
Fix documentation: array cannot be used

### DIFF
--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -63,8 +63,8 @@ module Dry
       # @example with a nested array of structs
       #   class Language < Dry::Struct
       #     attribute :name, Types::String
-      #     array :versions, Types::String
-      #     array :celebrities, Types::Array.of(Dry::Struct) do
+      #     attribute :versions, Types::Array.of(Types::String)
+      #     attribute :celebrities, Types::Array.of(Dry::Struct) do
       #       attribute :name, Types::String
       #       attribute :pseudonym, Types::String
       #     end


### PR DESCRIPTION
The examples in the docs are not working, because there is no `array` method defined.