### PR TITLE
Add experimental support for pattern matching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ dist: trusty
 sudo: required
 bundler_args: --without benchmarks tools
 script:
-  - bundle exec rake spec
+  - bundle exec rspec spec $RSPEC_OPTS
 after_success:
-  - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
+  - "[ -d coverage ] && bundle exec codeclimate-test-reporter"
 rvm:
   - 2.4.5
   - 2.5.5
@@ -16,14 +16,12 @@ env:
   global:
     - COVERAGE=true
     - JRUBY_OPTS='--dev -J-Xmx1024M'
+    - RSPEC_OPTS='--exclude-pattern spec/dry/struct/pattern_matching_spec.rb'
 matrix:
+  include:
+    - rvm: 2.7
+      env: "RSPEC_OPTS=''"
   allow_failures:
     - rvm: truffleruby
 notifications:
   email: false
-  webhooks:
-    urls:
-      - https://webhooks.gitter.im/e/19098b4253a72c9796db
-    on_success: change  # options: [always|never|change] default: always
-    on_failure: always  # options: [always|never|change] default: always
-    on_start: false     # default: false

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 
 group :test do
   gem 'codeclimate-test-reporter', platform: :mri, require: false
+  gem 'dry-monads'
   gem 'simplecov', require: false
   gem 'warning'
 end

--- a/lib/dry/struct.rb
+++ b/lib/dry/struct.rb
@@ -183,6 +183,13 @@ module Dry
       attrs = klass.attribute_names.map { |key| " #{key}=#{@attributes[key].inspect}" }.join
       "#<#{ klass.name || klass.inspect }#{ attrs }>"
     end
+
+    # Pattern matching support
+    #
+    # @api private
+    def deconstruct
+      [attributes]
+    end
   end
 end
 

--- a/lib/dry/struct.rb
+++ b/lib/dry/struct.rb
@@ -184,11 +184,13 @@ module Dry
       "#<#{ klass.name || klass.inspect }#{ attrs }>"
     end
 
-    # Pattern matching support
-    #
-    # @api private
-    def deconstruct
-      [attributes]
+    if RUBY_VERSION >= '2.7'
+      # Pattern matching support
+      #
+      # @api private
+      def deconstruct
+        [attributes]
+      end
     end
   end
 end

--- a/spec/dry/struct/pattern_matching_spec.rb
+++ b/spec/dry/struct/pattern_matching_spec.rb
@@ -1,0 +1,120 @@
+require 'dry/monads'
+
+RSpec.describe 'pattern matching' do
+  let(:struct) do
+    Dry.Struct(
+      first_name: 'string',
+      last_name: 'string',
+      address: Dry.Struct(
+        city: 'string',
+        street: 'string'
+      ).tap { |s| stub_const('Address', s) }
+    ).tap { |s| stub_const('User', s) }
+  end
+
+  let(:john) do
+    struct.(
+      first_name: 'John',
+      last_name: 'Doe',
+      address: {
+        city: 'Barcelona',
+        street: 'Carrer de Mallorca'
+      }
+    )
+  end
+
+  let(:jack) { john.new(first_name: 'Jack') }
+
+  let(:boris) do
+    struct.(
+      first_name: 'Boris',
+      last_name: 'Johnson',
+      address: {
+        city: 'London',
+        street: 'Downing street'
+      }
+    )
+  end
+
+  let(:alice) { john.new(first_name: 'Alice') }
+
+  let(:carol) { john.new(first_name: 'Carol') }
+
+  context 'pattern matching' do
+    def match(user)
+      case user
+      in User({ first_name: 'Jack' })
+        "It's Jack"
+      in User({ first_name: 'Alice' | 'Carol' })
+        'Alice or Carol'
+      in User({ first_name:, last_name: 'Doe' })
+        "DOE, #{first_name.upcase}"
+      in User({ first_name:, last_name: 'Doe' })
+        "DOE, #{first_name.upcase}"
+      in User({ first_name:, address: Address({ street: 'Downing street' }) })
+        "PM is #{first_name}"
+      end
+    end
+
+    specify do
+      expect(match(john)).to eql('DOE, JOHN')
+      expect(match(jack)).to eql("It's Jack")
+      expect(match(boris)).to eql('PM is Boris')
+      expect(match(alice)).to eql('Alice or Carol')
+      expect(match(carol)).to eql('Alice or Carol')
+    end
+
+    example 'collecting name' do
+      case john
+      in User({ address: _, **name })
+        expect(name).to eql(first_name: 'John', last_name: 'Doe')
+      end
+    end
+
+    example 'multiple structs' do
+      case john
+      in User({ first_name: 'John' } | { first_name: 'Jack' })
+      end
+    end
+  end
+
+  context 'using with monads' do
+    include Dry::Monads[:result, :maybe]
+
+    let(:matching_context) do
+      module Test
+        class Operation
+          include Dry::Monads[:result]
+
+          def call(result)
+            case result
+            in Success(User({ first_name: }))
+              "Name is #{first_name}"
+            in Failure[:not_found]
+              "Wasn't found"
+            in Failure[error]
+              "Error: #{error.inspect}, no meta given"
+            in Failure[error, meta]
+              "Error: #{error.inspect}, meta: #{meta.inspect}"
+            end
+          end
+        end
+      end
+      Test::Operation
+    end
+
+    def match(result)
+      matching_context.new.(result)
+    end
+
+    it 'matches results' do
+      expect(match(Success(john))).to eql('Name is John')
+      expect(match(Success(boris))).to eql('Name is Boris')
+      expect(match(Failure([:not_found]))).to eql("Wasn't found")
+      expect(match(Failure([:not_valid]))).to eql("Error: :not_valid, no meta given")
+      expect(match(Failure([:not_valid, name: 'Too short']))).to eql(
+        %q[Error: :not_valid, meta: {:name=>"Too short"}]
+      )
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,14 +12,11 @@ if RUBY_ENGINE == 'ruby' && ENV['COVERAGE'] == 'true'
 end
 
 require 'pathname'
-
-begin
-  require 'warning'
-  Warning.ignore(/regexp_parser/)
-  Warning.ignore(/parser/)
-  Warning.ignore(/slice\.rb/)
-rescue LoadError
-end
+require 'warning'
+Warning.ignore(/regexp_parser/)
+Warning.ignore(/parser/)
+Warning.ignore(/slice\.rb/)
+Warning.ignore(/Pattern matching/)
 
 module DryStructSpec
   ROOT = Pathname.new(__dir__).parent.expand_path.freeze


### PR DESCRIPTION
This is Ruby 2.7+

Example:
```ruby
class User < Dry::Struct
  attribute :first_name, 'string'
  attribute :last_name, 'string'
  attribute(:address) do
    attribute :city, 'string'
    attribute :street, 'string'
  end
end

case user
in User({ first_name: 'Jack' })
  "It's Jack"
in User({ first_name: 'Alice' | 'Carol' })
  'Alice or Carol'
in User({ first_name:, last_name: 'Doe' })
  "DOE, #{first_name.upcase}"
in User({ first_name:, last_name: 'Doe' })
  "DOE, #{first_name.upcase}"
in User({ first_name:, address: User::Address({ street: 'Downing street' }) })
  "PM is #{first_name}"
end
```

With dry-monads 1.3:

```ruby
module Test
  class Operation
    include Dry::Monads[:result]

    def call(result)
      case result
      in Success(User({ first_name: }))
        "Name is #{first_name}"
      in Failure[:not_found]
        "Wasn't found"
      in Failure[error]
        "Error: #{error.inspect}, no meta given"
      in Failure[error, meta]
        "Error: #{error.inspect}, meta: #{meta.inspect}"
      end
    end
  end
end
```