### PR TITLE
Exclude specs using ruby 2.7 on spec_helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 sudo: required
 bundler_args: --without benchmarks tools
 script:
-  - bundle exec rspec spec $RSPEC_OPTS
+  - bundle exec rspec spec
 after_success:
   - "[ -d coverage ] && bundle exec codeclimate-test-reporter"
 rvm:
@@ -16,11 +16,9 @@ env:
   global:
     - COVERAGE=true
     - JRUBY_OPTS='--dev -J-Xmx1024M'
-    - RSPEC_OPTS='--exclude-pattern spec/dry/struct/pattern_matching_spec.rb'
 matrix:
   include:
     - rvm: 2.7
-      env: "RSPEC_OPTS=''"
   allow_failures:
     - rvm: truffleruby
 notifications:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,6 +37,9 @@ Dir[Pathname(__dir__).join('shared/*.rb')].each(&method(:require))
 require 'dry/types/spec/types'
 
 RSpec.configure do |config|
+  config.exclude_pattern = '**/pattern_matching_spec.rb' \
+    unless RUBY_VERSION >= '2.7'
+
   config.before do
     @types = Dry::Types.container._container.keys
 


### PR DESCRIPTION
With this, we can use the suite locally if not using ruby 2.7 nor
adding the --exclude_pattern flag