### PR TITLE
Switch to immutable equalizer

### DIFF
--- a/dry-struct.gemspec
+++ b/dry-struct.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = ">= 2.4.0"
 
-  spec.add_runtime_dependency 'dry-equalizer', '~> 0.2'
+  spec.add_runtime_dependency 'dry-equalizer', '~> 0.3'
   spec.add_runtime_dependency 'dry-types', '~> 1.0'
   spec.add_runtime_dependency 'dry-core', '~> 0.4', '>= 0.4.3'
   spec.add_runtime_dependency 'ice_nine', '~> 0.11'

--- a/lib/dry/struct.rb
+++ b/lib/dry/struct.rb
@@ -82,11 +82,11 @@ module Dry
   #   refactoring.title #=> 'Refactoring'
   #   refactoring.subtitle #=> 'Improving the Design of Existing Code'
   class Struct
-    extend Dry::Core::Extensions
-    include Dry::Core::Constants
+    extend Core::Extensions
+    include Core::Constants
     extend ClassInterface
 
-    include Dry::Equalizer(:__attributes__)
+    include ::Dry::Equalizer(:__attributes__, inspect: false, immutable: true)
 
     # {Dry::Types::Hash::Schema} subclass with specific behaviour defined for
     # @return [Dry::Types::Hash::Schema]
@@ -173,7 +173,7 @@ module Dry
       new_attributes = self.class.schema.apply(changeset, skip_missing: true, resolve_defaults: false)
       self.class.load(__attributes__.merge(new_attributes))
     rescue Types::SchemaError, Types::MissingKeyError, Types::UnknownKeysError => error
-      raise Struct::Error, "[#{self}.new] #{error}"
+      raise Error, "[#{self}.new] #{error}"
     end
     alias_method :__new__, :new
 
@@ -181,7 +181,7 @@ module Dry
     def inspect
       klass = self.class
       attrs = klass.attribute_names.map { |key| " #{key}=#{@attributes[key].inspect}" }.join
-      "#<#{ klass.name || klass.inspect }#{ attrs }>"
+      "#<#{klass.name || klass.inspect}#{attrs}>"
     end
 
     if RUBY_VERSION >= '2.7'

--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -12,8 +12,8 @@ module Dry
     module ClassInterface
       include Core::ClassAttributes
 
-      include Dry::Types::Type
-      include Dry::Types::Builder
+      include Types::Type
+      include Types::Builder
 
       # @param [Class] klass
       def inherited(klass)
@@ -25,7 +25,7 @@ module Dry
           @meta = base.meta
 
           unless equal?(Value)
-            extend Dry::Core::DescendantsTracker
+            extend Core::DescendantsTracker
           end
         end
       end
@@ -116,7 +116,7 @@ module Dry
       #
       def attribute?(*args, &block)
         if args.size == 1 && block.nil?
-          Dry::Core::Deprecations.warn(
+          Core::Deprecations.warn(
             'Dry::Struct.attribute? is deprecated for checking attribute presence, '\
             'use has_attribute? instead',
             tag: :'dry-struct'
@@ -231,7 +231,7 @@ module Dry
           load(schema.call_unsafe(attributes))
         end
       rescue Types::CoercionError => error
-        raise Struct::Error, "[#{self}.new] #{error}"
+        raise Error, "[#{self}.new] #{error}"
       end
 
       # @api private
@@ -264,7 +264,7 @@ module Dry
       # @param [#call,nil] block
       # @return [Dry::Struct::Constructor]
       def constructor(constructor = nil, **_options, &block)
-        Struct::Constructor.new(self, fn: constructor || block)
+        Constructor.new(self, fn: constructor || block)
       end
 
       # @param [Hash{Symbol => Object},Dry::Struct] input
@@ -273,7 +273,7 @@ module Dry
       # @return [Dry::Types::Result]
       def try(input)
         success(self[input])
-      rescue Struct::Error => e
+      rescue Error => e
         failure_result = failure(input, e.message)
         block_given? ? yield(failure_result) : failure_result
       end
@@ -298,7 +298,7 @@ module Dry
       # @param [({Symbol => Object})] args
       # @return [Dry::Types::Result::Failure]
       def failure(*args)
-        result(::Dry::Types::Result::Failure, *args)
+        result(Types::Result::Failure, *args)
       end
 
       # @param [Class] klass
@@ -359,7 +359,7 @@ module Dry
         if meta.equal?(Undefined)
           @meta
         else
-          Class.new(self) do
+          ::Class.new(self) do
             @meta = @meta.merge(meta) unless meta.empty?
           end
         end
@@ -369,8 +369,8 @@ module Dry
       # @param [Dry::Types::Type] type
       # @return [Dry::Types::Sum]
       def |(type)
-        if type.is_a?(Class) && type <= Struct
-          Struct::Sum.new(self, type)
+        if type.is_a?(::Class) && type <= Struct
+          Sum.new(self, type)
         else
           super
         end
@@ -399,7 +399,7 @@ module Dry
       # @param [Dry::Types::Type] type
       # @return [Boolean]
       def struct?(type)
-        type.is_a?(Class) && type <= Struct
+        type.is_a?(::Class) && type <= Struct
       end
       private :struct?
 
@@ -408,11 +408,11 @@ module Dry
       # @return [Dry::Types::Type, Dry::Struct]
       def build_type(name, type, &block)
         type_object =
-          if type.is_a?(String)
-            Dry::Types[type]
+          if type.is_a?(::String)
+            Types[type]
           elsif block.nil? && type.nil?
             raise(
-              ArgumentError,
+              ::ArgumentError,
               'you must supply a type or a block to `Dry::Struct.attribute`'
             )
           else

--- a/spec/shared/struct.rb
+++ b/spec/shared/struct.rb
@@ -79,6 +79,10 @@ RSpec.shared_examples_for Dry::Struct do
       expect(updated.name).to eql(:'Jane Doe')
     end
 
+    it 'raises a Struct::Error on invalid input' do
+      expect { original.new(age: 'aabb') }.to raise_error(Dry::Struct::Error)
+    end
+
     context 'default values' do
       subject(:struct) do
         Class.new(Dry::Struct) {

--- a/spec/shared/struct.rb
+++ b/spec/shared/struct.rb
@@ -302,5 +302,14 @@ RSpec.shared_examples_for Dry::Struct do
         expect(struct_b.valid?(struct_a.(name: 'John'))).to be(true)
       end
     end
+
+    describe '.try' do
+      let(:struct) { Dry::Struct(name: 'string') }
+
+      it 'returns a result object' do
+        expect(struct.try(name: 'John')).to be_a(Dry::Types::Result::Success)
+        expect(struct.try(name: 42)).to be_a(Dry::Types::Result::Failure)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR switches dry-struct to use [immutable equalizer](https://github.com/dry-rb/dry-equalizer/releases/tag/v0.3.0) by default. We always treated structs as immutable objects. The only actual reason structs are not frozen is calling `.freeze` affects performance. That said, this may be a breaking change for some users of dry-struct. To use the mutable equalizer, subclass `Dry::Struct` and include a new module:
```ruby
class MutableStruct < Dry::Struct
  include Dry::Equalizer(:__attributes__, inspect: false)
end
```