### PR TITLE
Deprecate Dry::Struct::Value

### DIFF
--- a/lib/dry/struct.rb
+++ b/lib/dry/struct.rb
@@ -195,6 +195,5 @@ module Dry
   end
 end
 
-require 'dry/struct/value'
 require 'dry/struct/extensions'
 require 'dry/struct/printer'

--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -24,7 +24,7 @@ module Dry
         klass.class_eval do
           @meta = base.meta
 
-          unless equal?(Value)
+          unless name.eql?('Dry::Struct::Value')
             extend Core::DescendantsTracker
           end
         end

--- a/lib/dry/struct/struct_builder.rb
+++ b/lib/dry/struct/struct_builder.rb
@@ -3,11 +3,11 @@ require 'dry/types/compiler'
 module Dry
   class Struct
     # @private
-    class StructBuilder < Dry::Types::Compiler
+    class StructBuilder < Types::Compiler
       attr_reader :struct
 
       def initialize(struct)
-        super(Dry::Types)
+        super(Types)
         @struct = struct
       end
 
@@ -18,7 +18,7 @@ module Dry
         const_name = const_name(type, attr_name)
         check_name(const_name)
 
-        new_type = Class.new(parent(type), &block)
+        new_type = ::Class.new(parent(type), &block)
         struct.const_set(const_name, new_type)
 
         if array?(type)
@@ -31,7 +31,7 @@ module Dry
       private
 
       def array?(type)
-        type.is_a?(Types::Type) && type.primitive.equal?(Array)
+        type.is_a?(Types::Type) && type.primitive.equal?(::Array)
       end
 
       def parent(type)
@@ -43,22 +43,27 @@ module Dry
       end
 
       def default_superclass
-        struct < Value ? Value : Struct
+        if defined? ::Dry::Struct::Value
+          struct < Value ? Value : Struct
+        else
+          Struct
+        end
       end
 
       def const_name(type, attr_name)
-        snake_name = if array?(type)
-                       Dry::Core::Inflector.singularize(attr_name)
-                     else
-                       attr_name
-                     end
+        snake_name =
+          if array?(type)
+            Core::Inflector.singularize(attr_name)
+          else
+            attr_name
+          end
 
-        Dry::Core::Inflector.camelize(snake_name)
+        Core::Inflector.camelize(snake_name)
       end
 
       def check_name(name)
         raise(
-          Struct::Error,
+          Error,
           "Can't create nested attribute - `#{struct}::#{name}` already defined"
         ) if struct.const_defined?(name, false)
       end

--- a/lib/dry/struct/value.rb
+++ b/lib/dry/struct/value.rb
@@ -1,7 +1,10 @@
 require 'ice_nine'
+require 'dry/core/deprecations'
 
 module Dry
   class Struct
+    extend Core::Deprecations[:'dry-struct']
+
     # {Value} objects behave like {Struct}s but *deeply frozen*
     # using [`ice_nine`](https://github.com/dkubb/ice_nine)
     #
@@ -24,8 +27,10 @@ module Dry
       # @return [Value]
       # @see https://github.com/dkubb/ice_nine
       def self.new(*)
-        IceNine.deep_freeze(super)
+        ::IceNine.deep_freeze(super)
       end
     end
+
+    deprecate_constant :Value
   end
 end

--- a/spec/dry/struct/value_spec.rb
+++ b/spec/dry/struct/value_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
-RSpec.describe Dry::Struct::Value do
+RSpec.describe 'Dry::Struct::Value', :suppress_deprecations do
   before do
+    require 'dry/struct/value'
+
     module Test
       class Address < Dry::Struct::Value
         attribute :city, 'strict.string'

--- a/spec/dry/struct_spec.rb
+++ b/spec/dry/struct_spec.rb
@@ -139,7 +139,9 @@ RSpec.describe Dry::Struct do
     expect(described_class.method(:[])).to eq described_class.method(:call)
   end
 
-  describe '.inherited' do
+  describe '.inherited', :suppress_deprecations do
+    before { require 'dry/struct/value' }
+
     it 'does not register Value' do
       expect { Dry::Struct.inherited(Dry::Struct::Value) }
         .to_not change(Dry::Types, :type_keys)
@@ -280,13 +282,20 @@ RSpec.describe Dry::Struct do
       end
     end
 
-    context 'on an Dry::Types::Hash.map with nested types' do
-      NestedType = Class.new(Dry::Struct::Value) do
-        attribute :age, Dry::Types['strict.integer']
+    context 'on an Dry::Types::Hash.map with nested types', :suppress_deprecations do
+      before { require 'dry/struct/value' }
+
+      let(:nested_type) do
+        Class.new(Dry::Struct::Value) do
+          attribute :age, Dry::Types['strict.integer']
+        end
       end
 
-      type = Class.new(Dry::Struct) do
-        attribute :people, Dry::Types['hash'].map(Dry::Types['strict.string'], NestedType)
+      let(:type) do
+        nested_type = self.nested_type
+        Class.new(Dry::Struct) do
+          attribute :people, Dry::Types['hash'].map(Dry::Types['strict.string'], nested_type)
+        end
       end
 
       it 'hashifies the values within the hash map' do

--- a/spec/shared/struct.rb
+++ b/spec/shared/struct.rb
@@ -237,7 +237,9 @@ RSpec.shared_examples_for Dry::Struct do
       end
     end
 
-    describe '.inherited' do
+    describe '.inherited', :suppress_deprecations do
+      before { require 'dry/struct/value' }
+
       it "doesn't track Struct/Value descendats" do
         expect(Dry::Struct).not_to be_a(Dry::Core::DescendantsTracker)
         expect(Dry::Struct::Value).not_to be_a(Dry::Core::DescendantsTracker)


### PR DESCRIPTION
It has little use; we already treat structs as immutable objects. Making structs mutable never worked well, we always discouraged people from using them this way. In this light, having Dry::Struct::Value doesn't add anything, it's an example of defensive programming that slows code down without clear benefit. This commit deprecates Dry::Struct::Value, dry-struct 2.0 will remove it completely.