### PR TITLE
Keep types and keys transformations for nested structs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ eval_gemfile 'Gemfile.devtools'
 
 gemspec
 
+gem 'dry-types', github: 'dry-rb/dry-types'
+
 group :test do
   gem 'dry-monads'
   gem 'warning'

--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -98,7 +98,7 @@ module Dry
       #   ruby.celebrities[0].pseudonym #=> 'Matz'
       #   ruby.celebrities[1].name #=> 'Aaron Patterson'
       #   ruby.celebrities[1].pseudonym #=> 'tenderlove'
-      def attribute(name, type = nil, &block)
+      def attribute(name, type = Undefined, &block)
         attributes(name => build_type(name, type, &block))
       end
 
@@ -126,9 +126,9 @@ module Dry
 
           has_attribute?(args[0])
         else
-          name, type = args
+          name, * = args
 
-          attribute(:"#{ name }?", build_type(name, type, &block))
+          attribute(:"#{name}?", build_type(*args, &block))
         end
       end
 
@@ -409,11 +409,11 @@ module Dry
       # Constructs a type
       #
       # @return [Dry::Types::Type, Dry::Struct]
-      def build_type(name, type, &block)
+      def build_type(name, type = Undefined, &block)
         type_object =
           if type.is_a?(::String)
             Types[type]
-          elsif block.nil? && type.nil?
+          elsif block.nil? && Undefined.equal?(type)
             raise(
               ::ArgumentError,
               'you must supply a type or a block to `Dry::Struct.attribute`'

--- a/project.yml
+++ b/project.yml
@@ -10,7 +10,7 @@ gemspec:
     - rspec
     - yard
   runtime_dependencies:
-    - [dry-core, "~> 0.4", ">= 0.4.3"]
+    - [dry-core, "~> 0.4", ">= 0.4.4"]
     - [dry-equalizer, "~> 0.3"]
-    - [dry-types, "~> 1.0"]
+    - [dry-types, "~> 1.3"]
     - [ice_nine, "~> 0.11"]

--- a/spec/dry/struct/attribute_dsl/definition_spec.rb
+++ b/spec/dry/struct/attribute_dsl/definition_spec.rb
@@ -208,9 +208,9 @@ RSpec.describe Dry::Struct, method: '.attribute' do
 
     it 'defines omittable structs' do
       class Test::Foo < Dry::Struct
-        attribute  :foo, 'strict.string'
+        attribute  :foo, 'string'
         attribute? :nested do
-          attribute :bar, 'strict.string'
+          attribute :bar, 'string'
         end
       end
 

--- a/spec/dry/struct_spec.rb
+++ b/spec/dry/struct_spec.rb
@@ -142,11 +142,6 @@ RSpec.describe Dry::Struct do
   describe '.inherited', :suppress_deprecations do
     before { require 'dry/struct/value' }
 
-    it 'does not register Value' do
-      expect { Dry::Struct.inherited(Dry::Struct::Value) }
-        .to_not change(Dry::Types, :type_keys)
-    end
-
     it 'adds attributes to all descendants' do
       Test::User.attribute(:signed_on, Dry::Types['strict.time'])
 
@@ -356,8 +351,8 @@ RSpec.describe Dry::Struct do
     describe 'protected methods' do
       before do
         class Test::Task
-          attribute :hash, Dry::Types['strict.string']
-          attribute :attributes, Dry::Types['array'].of(Dry::Types['strict.string'])
+          attribute :hash, Dry::Types['string']
+          attribute :attributes, Dry::Types['array'].of(Dry::Types['string'])
         end
       end
 

--- a/spec/shared/struct.rb
+++ b/spec/shared/struct.rb
@@ -71,7 +71,7 @@ RSpec.shared_examples_for Dry::Struct do
     it 'uses attribute values, not accessors result' do
       decorator = Module.new do
         def name
-          :"#{ super } Doe"
+          :"#{super} Doe"
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,13 @@
 # frozen_string_literal: true
 
 require_relative 'support/coverage'
+require_relative 'support/warnings'
 
 require 'pathname'
-require 'warning'
 
-Warning.ignore(/codacy/)
 Warning.ignore(/regexp_parser/)
 Warning.ignore(/parser/)
 Warning.ignore(/slice\.rb/)
-Warning.ignore(/Pattern matching/)
 
 module DryStructSpec
   ROOT = Pathname.new(__dir__).parent.expand_path.freeze


### PR DESCRIPTION
It's done in a smart way. Unless you explicitly provided a struct, transformations from the containing struct will be used. It works like this:

```ruby
class User < Dry::Struct
  transform_keys(&:to_sym)

  attribute :name, Types::String
  attribute :address do
    # there transform_keys(&:to_sym) is inherited
    attribute :city, Types::String
  end
end
```
However, if you do
```ruby
  attribute :address, Dry::Struct do
    ...
  end
```
^it will not convert keys for `:address`