### PR TITLE
Deprecate Struct#to_hash

### DIFF
--- a/lib/dry/struct.rb
+++ b/lib/dry/struct.rb
@@ -4,6 +4,7 @@ require 'dry-types'
 require 'dry-equalizer'
 require 'dry/core/extensions'
 require 'dry/core/constants'
+require 'dry/core/deprecations'
 
 require 'dry/struct/version'
 require 'dry/struct/errors'
@@ -87,6 +88,7 @@ module Dry
     extend Core::Extensions
     include Core::Constants
     extend ClassInterface
+    extend Core::Deprecations[:'dry-struct']
 
     class << self
       # override `Dry::Types::Builder#prepend`
@@ -151,12 +153,12 @@ module Dry
     #   )
     #   rom_n_roda.to_hash
     #     #=> {title: 'Web Development with ROM and Roda', subtitle: nil}
-    def to_hash
+    def to_h
       self.class.schema.each_with_object({}) do |key, result|
         result[key.name] = Hashify[self[key.name]] if attributes.key?(key.name)
       end
     end
-    alias_method :to_h, :to_hash
+    deprecate :to_hash, :to_h, message: "Implicit convertion structs to hashes is deprecated. Use .to_h"
 
     # Create a copy of {Dry::Struct} with overriden attributes
     #

--- a/lib/dry/struct/hashify.rb
+++ b/lib/dry/struct/hashify.rb
@@ -8,7 +8,9 @@ module Dry
       # @param [#to_hash, #map, Object] value
       # @return [Hash, Array]
       def self.[](value)
-        if value.respond_to?(:to_hash)
+        if value.is_a?(Struct)
+          value.to_h.transform_values { |current| self[current] }
+        elsif value.respond_to?(:to_hash)
           value.to_hash.transform_values { |current| self[current] }
         elsif value.respond_to?(:to_ary)
           value.to_ary.map { |item| self[item] }

--- a/spec/dry/struct_spec.rb
+++ b/spec/dry/struct_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe Dry::Struct do
         ]
       }
 
-      expect(parent_type[attributes].to_hash).to eql(attributes)
+      expect(parent_type[attributes].to_h).to eql(attributes)
     end
 
     it "doesn't unwrap blindly anything mappable" do
@@ -244,7 +244,7 @@ RSpec.describe Dry::Struct do
         end
 
         attributes = { name: 'John' }
-        expect(type.new(attributes).to_hash).to eq (attributes)
+        expect(type.new(attributes).to_h).to eql(attributes)
       end
 
       it 'returns hash with attributes but will fetch omittable keys if set' do
@@ -254,7 +254,7 @@ RSpec.describe Dry::Struct do
         end
 
         attributes = { name: 'John', last_name: 'Doe' }
-        expect(type.new(attributes).to_hash).to eq (attributes)
+        expect(type.new(attributes).to_h).to eql(attributes)
       end
 
       it 'returns empty hash if all attributes are ommitable and no value is set' do
@@ -262,7 +262,7 @@ RSpec.describe Dry::Struct do
           attribute :name, Dry::Types['string'].meta(required: false)
         end
 
-        expect(type.new.to_hash).to eq ({})
+        expect(type.new.to_h).to eql({})
       end
     end
 
@@ -273,7 +273,7 @@ RSpec.describe Dry::Struct do
         end
 
         attributes = { name: 'John' }
-        expect(type.new.to_hash).to eq (attributes)
+        expect(type.new.to_h).to eql(attributes)
       end
     end
 
@@ -295,7 +295,7 @@ RSpec.describe Dry::Struct do
 
       it 'hashifies the values within the hash map' do
         attributes = { people: { 'John' => { age: 35 } } }
-        expect(type.new(attributes).to_hash).to eq(attributes)
+        expect(type.new(attributes).to_h).to eql(attributes)
       end
     end
   end


### PR DESCRIPTION
It served us poorly. .to_hash is used by ruby implicitly for converting values to keywords. This is not needed for structs. As a step 1, we deprecate `#to_hash` to understand the impact of further removal. Users can define `#to_hash` at will.