### PR TITLE
Abstract structs

### DIFF
--- a/lib/dry/struct.rb
+++ b/lib/dry/struct.rb
@@ -104,6 +104,9 @@ module Dry
     defines :schema
     schema Types['coercible.hash'].schema(EMPTY_HASH)
 
+    defines :abstract_class
+    abstract
+
     @meta = EMPTY_HASH
 
     # @!attribute [Hash{Symbol => Object}] attributes

--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -416,6 +416,12 @@ module Dry
         end
       end
 
+      # Make the struct abstract. This class will be used as a default
+      # parent class for nested structs
+      def abstract
+        abstract_class self
+      end
+
       # Stores an object for building nested struct classes
       # @return [StructBuilder]
       def struct_builder
@@ -466,12 +472,6 @@ module Dry
         end
       end
       private :build_type
-
-      # @api private
-      # @return [Boolean]
-      def value?
-        false
-      end
     end
   end
 end

--- a/lib/dry/struct/struct_builder.rb
+++ b/lib/dry/struct/struct_builder.rb
@@ -23,7 +23,7 @@ module Dry
         builder = self
         parent = parent(type)
 
-        new_type = ::Class.new(Undefined.default(parent, default_superclass)) do
+        new_type = ::Class.new(Undefined.default(parent, struct.abstract_class)) do
           if Undefined.equal?(parent)
             schema builder.struct.schema.clear
           end
@@ -51,10 +51,6 @@ module Dry
         else
           type
         end
-      end
-
-      def default_superclass
-        struct.value? ? Value : Struct
       end
 
       def const_name(type, attr_name)

--- a/lib/dry/struct/value.rb
+++ b/lib/dry/struct/value.rb
@@ -25,17 +25,13 @@ module Dry
     #
     # @see https://github.com/dkubb/ice_nine
     class Value < self
+      abstract
+
       # @param (see ClassInterface#new)
       # @return [Value]
       # @see https://github.com/dkubb/ice_nine
       def self.new(*)
         ::IceNine.deep_freeze(super)
-      end
-
-      # @api private
-      # @return [Boolean]
-      def self.value?
-        true
       end
     end
 

--- a/spec/dry/struct/attribute_dsl/abstract_struct_spec.rb
+++ b/spec/dry/struct/attribute_dsl/abstract_struct_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Struct, method: '.abstract' do
+  before do
+    class Test::Abstract < Dry::Struct
+      abstract
+
+      transform_keys(&:to_sym)
+
+      def key?(key)
+        attributes.key?(key)
+      end
+    end
+  end
+
+  it 'is reused as a base class in descendants' do
+    class Test::User < Test::Abstract
+      attribute :name, 'string'
+
+      attribute :address do
+        attribute :city, 'string'
+      end
+    end
+
+    user = Test::User.('name' => 'John', 'address' => { 'city' => 'Mexico' })
+
+    expect(user.to_h).to eql(
+      name: 'John',
+      address: { city: 'Mexico' }
+    )
+    expect(Test::User::Address).to be < Test::Abstract
+    expect(user.address.key?(:city)).to be(true)
+    expect(user.address.key?(:street)).to be(false)
+  end
+end


### PR DESCRIPTION
Abstract struct will be used as a base class for nested structs.

```ruby
class AbstractStruct < Dry::Struct
  abstract

  transform_keys(&:to_sym)

  def key?(key)
    attributes.key?(key)
  end
end

class User < AbstractStruct
  attribute :name, 'string'

  attribute :address do
    attribute :city, 'string'
  end
end
```
^here `AbstractStruct` will be the superclass of `User::Address`