### PR TITLE
Implement Struct.to_ast

### DIFF
--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -391,6 +391,8 @@ module Dry
       def meta(meta = Undefined)
         if meta.equal?(Undefined)
           schema.meta
+        elsif meta.empty?
+          self
         else
           ::Class.new(self) do
             schema schema.meta(meta) unless meta.empty?
@@ -413,6 +415,15 @@ module Dry
       # parent class for nested structs
       def abstract
         abstract_class self
+      end
+
+      # Dump to the AST
+      #
+      # @return [Array]
+      #
+      # @api public
+      def to_ast(meta: true)
+        [:struct, [self, schema.to_ast(meta: meta)]]
       end
 
       # Stores an object for building nested struct classes

--- a/lib/dry/struct/compiler.rb
+++ b/lib/dry/struct/compiler.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'dry/types/compiler'
+
+module Dry
+  class Struct
+    class Compiler < Types::Compiler
+      def visit_struct(node)
+        struct, _ = node
+
+        struct
+      end
+    end
+  end
+end

--- a/lib/dry/struct/struct_builder.rb
+++ b/lib/dry/struct/struct_builder.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'dry/types/compiler'
+require 'dry/struct/compiler'
 
 module Dry
   class Struct
     # @private
-    class StructBuilder < Types::Compiler
+    class StructBuilder < Compiler
       attr_reader :struct
 
       def initialize(struct)
@@ -78,7 +78,7 @@ module Dry
 
       def visit_array(node)
         member, * = node
-        member
+        visit(member)
       end
 
       def visit_nominal(*)

--- a/spec/integration/compile_spec.rb
+++ b/spec/integration/compile_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'dry/struct/compiler'
+
+RSpec.describe Dry::Struct::Compiler do
+  subject(:compiler) { described_class.new(Dry::Types) }
+
+  let(:address) do
+    Dry.Struct(street: 'string', city?: 'optional.string')
+  end
+
+  it 'compiles struct back to the same class' do
+    expect(compiler.(address.to_ast)).to be(address)
+  end
+
+  context 'struct constructor' do
+    let(:address) { super().constructor(:itself.to_proc) }
+
+    specify do
+      expect(compiler.(address.to_ast)).to eql(address)
+    end
+  end
+
+  context 'optional struct' do
+    let(:address) { super().optional }
+
+    specify do
+      expect(compiler.(address.to_ast)).to eql(address)
+    end
+  end
+end

--- a/spec/unit/struct_spec.rb
+++ b/spec/unit/struct_spec.rb
@@ -1,0 +1,43 @@
+
+# frozen_string_literal: true
+
+require 'dry/struct'
+
+RSpec.describe Dry::Struct do
+  describe '.to_ast' do
+    let(:address) do
+      Dry.Struct(street: 'string', city?: 'optional.string')
+    end
+
+    example 'simple AST' do
+      expect(address.to_ast).to eql(
+        [
+          :struct,
+          [address, address.schema.to_ast]
+        ]
+      )
+    end
+
+    context 'with meta' do
+      let(:address) { super().meta(foo: :bar) }
+
+      specify 'on' do
+        expect(address.to_ast).to eql(
+          [
+            :struct,
+            [address, address.schema.to_ast(meta: true)]
+          ]
+        )
+      end
+
+      specify 'off' do
+        expect(address.to_ast(meta: false)).to eql(
+          [
+            :struct,
+            [address, address.schema.to_ast(meta: false)]
+          ]
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
I keep a reference to the original class in the AST because it's the only way to do it right. This shouldn't be a problem, though.

This PR also adds a struct compiler which we can reuse in dry-schema.