### PR TITLE
Rollback to_hash deprecation

### DIFF
--- a/lib/dry/struct.rb
+++ b/lib/dry/struct.rb
@@ -159,7 +159,8 @@ module Dry
         result[key.name] = Hashify[self[key.name]] if attributes.key?(key.name)
       end
     end
-    deprecate :to_hash, :to_h, message: "Implicit convertion structs to hashes is deprecated. Use .to_h"
+    alias_method :to_hash, :to_h
+    # deprecate :to_hash, :to_h, message: "Implicit convertion structs to hashes is deprecated. Use .to_h"
 
     # Create a copy of {Dry::Struct} with overriden attributes
     #

--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -247,7 +247,7 @@ module Dry
 
       # @param [Hash{Symbol => Object},Dry::Struct] attributes
       # @raise [Struct::Error] if the given attributes don't conform {#schema}
-      def new(attributes = default_attributes, safe = false)
+      def new(attributes = default_attributes, safe = false, &block)
         if attributes.is_a?(Struct)
           if equal?(attributes.class)
             attributes
@@ -257,7 +257,7 @@ module Dry
             # User.new(super_user)
             #
             # We may deprecate this behavior in future forcing people to be explicit
-            new(attributes.to_h, safe)
+            new(attributes.to_h, safe, &block)
           end
         elsif safe
           load(schema.call_safe(attributes) { |output = attributes| return yield output })

--- a/spec/integration/struct_spec.rb
+++ b/spec/integration/struct_spec.rb
@@ -56,6 +56,15 @@ RSpec.describe Dry::Struct do
       expect(construct_user(user)).to be_instance_of(user_type)
     end
 
+    it 'supports safe call when a struct is given' do
+      subtype = Class.new(root_type) { attribute :age, 'string' }
+      user = subtype[
+        name: :Jane, age: 'twenty-one', root: true, address: { city: 'NYC', zipcode: 123 }
+      ]
+
+      expect(root_type.new(user, true) { :fallback }).to be(:fallback)
+    end
+
     context 'with default' do
       it 'resolves missing values with defaults' do
         struct = Class.new(Dry::Struct) do


### PR DESCRIPTION
@solnic it's implicitly used by rom-changeset here https://github.com/rom-rb/rom/blob/212ccab204c49b64f8d81e03b6b3dc7c041d1182/changeset/lib/rom/changeset/update.rb#L68
It shouldn't be hard to fix if we change `auto_struct` to `false` for `original`, I'll file an issue there. For the time being, I'm rolling back the deprecation.