### PR TITLE
Update doc

### DIFF
--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -37,6 +37,8 @@ user.name # => "Jane"
 user.age # => 21
 ```
 
+<sub>Note: An `optional` type means that the value can be nil, not the key in the hash can be skipped.</sub>
+
 ### Value
 
 :warning: `Dry::Struct::Value` is deprecated in 1.2.0. Structs are already meant to be immutable, freezing them doesn't add any value (no pun intended) beyond a bad example of defensive programming.


### PR DESCRIPTION
For me it wasn't obvious `optional` type thing. It took me almost 1 day to realize it just allows nil values, instead of allowing to skip attribute at all.

I was about to bug report and then started searching for issues and came across https://github.com/dry-rb/dry-types/issues/19
After this I found section in Recipes about [tolerance to missing keys](https://dry-rb.org/gems/dry-struct/1.0/recipes/#tolerance-to-extra-keys)