### PR TITLE
Create base class from optional structs

### DIFF
--- a/lib/dry/struct/struct_builder.rb
+++ b/lib/dry/struct/struct_builder.rb
@@ -30,10 +30,13 @@ module Dry
 
           class_exec(&block)
         end
+
         struct.const_set(const_name, new_type)
 
         if array?(type)
           type.of(new_type)
+        elsif optional?(type)
+          new_type.optional
         else
           new_type
         end
@@ -41,13 +44,23 @@ module Dry
 
       private
 
+      def type?(type)
+        type.is_a?(Types::Type)
+      end
+
       def array?(type)
-        type.is_a?(Types::Type) && type.primitive.equal?(::Array)
+        type?(type) && !type.optional? && type.primitive.equal?(::Array)
+      end
+
+      def optional?(type)
+        type?(type) && type.optional?
       end
 
       def parent(type)
         if array?(type)
           visit(type.to_ast)
+        elsif optional?(type)
+          type.right
         else
           type
         end

--- a/spec/integration/attribute_dsl/definition_spec.rb
+++ b/spec/integration/attribute_dsl/definition_spec.rb
@@ -61,7 +61,9 @@ RSpec.describe Dry::Struct, method: ".attribute" do
 
         it "defines attributes for the constructor" do
           user = user_type[
-            name: :Jane, age: "21", address: {
+            name: :Jane,
+            age: "21",
+            address: {
               street: "123 Fake Street",
               city: "NYC",
               zipcode: 123
@@ -74,6 +76,21 @@ RSpec.describe Dry::Struct, method: ".attribute" do
 
         it "defines a nested type" do
           expect { user_type.const_get("Address") }.to_not raise_error
+        end
+
+        context "optional struct" do
+          let(:user_type) do
+            Class.new(Dry::Struct) do
+              attribute :name, "coercible.string"
+              attribute :address, Dry::Struct.optional do
+                attribute :city, "string"
+              end
+            end
+          end
+
+          it "accepts nil as input" do
+            expect { user_type[name: :Jane, address: nil] }.to_not raise_error
+          end
         end
       end
     end


### PR DESCRIPTION
This adds support for inferring base class from optional structs
```ruby
class User  < Dry::Struct
  attribute :address, Dry::Struct.optional do
    attribute :city, 'string'
  end
end
```
Resolves #156
It doesn't work in more complex cases like arrays of optionals or optional arrays but I doubt these cases are common enough to bother, there's always another way to implement them.