### PR TITLE
Fix pretty_print extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 
 .DS_Store
 .vscode
+.ruby-version
+.ruby-gemset

--- a/lib/dry/struct/extensions/pretty_print.rb
+++ b/lib/dry/struct/extensions/pretty_print.rb
@@ -11,7 +11,7 @@ module Dry
           column_value = @attributes[column_name]
           pp.breakable " "
           pp.group(1) do
-            pp.text column_name
+            pp.text column_name.to_s
             pp.text "="
             pp.pp column_value
           end

--- a/spec/extensions/pretty_print_spec.rb
+++ b/spec/extensions/pretty_print_spec.rb
@@ -1,54 +1,47 @@
 # frozen_string_literal: true
 
 RSpec.describe Dry::Struct do
-  describe "#pretty_print" do
+  describe "#pretty_inspect" do
     include_context "user type"
+
+    subject(:pretty_inspect) { user.pretty_inspect }
 
     before { Dry::Struct.load_extensions(:pretty_print) }
 
-    let(:string_io) { StringIO.new(String.new) }
-    subject(:actual) do
-      string_io.rewind
-      string_io.read
-    end
-    before { PP.pp(user, string_io) }
-
-    describe "#pretty_print" do
-      context "with Test::User" do
-        let(:user) do
-          user_type[
-            name: "Jane", age: 21,
-            address: {city: "NYC", zipcode: "123"}
-          ]
-        end
-
-        it do
-          should eql <<~PRETTY_PRINT
-            #<Test::User
-             name="Jane",
-             age=21,
-             address=#<Test::Address city="NYC", zipcode="123">>
-          PRETTY_PRINT
-        end
+    context "with Test::User" do
+      let(:user) do
+        user_type[
+          name: "Jane", age: 21,
+          address: {city: "NYC", zipcode: "123"}
+        ]
       end
 
-      context "with Test::SuperUSer" do
-        let(:user) do
-          root_type[
-            name: :Mike, age: 43, root: false,
-            address: {city: "Atlantis", zipcode: 456}
-          ]
-        end
+      it do
+        is_expected.to eql <<~PRETTY_INSPECT
+          #<Test::User
+           name="Jane",
+           age=21,
+           address=#<Test::Address city="NYC", zipcode="123">>
+        PRETTY_INSPECT
+      end
+    end
 
-        it do
-          should eql <<~PRETTY_PRINT
-            #<Test::SuperUser
-             name="Mike",
-             age=43,
-             root=false,
-             address=#<Test::Address city="Atlantis", zipcode="456">>
-          PRETTY_PRINT
-        end
+    context "with Test::SuperUSer" do
+      let(:user) do
+        root_type[
+          name: :Mike, age: 43, root: false,
+          address: {city: "Atlantis", zipcode: 456}
+        ]
+      end
+
+      it do
+        is_expected.to eql <<~PRETTY_INSPECT
+          #<Test::SuperUser
+           name="Mike",
+           age=43,
+           root=false,
+           address=#<Test::Address city="Atlantis", zipcode="456">>
+        PRETTY_INSPECT
       end
     end
   end


### PR DESCRIPTION
Hello folks, found an issue in the pretty_print extension.

Without this fix `pretty_inspect` method, which is used by, for example, RSpec to display a diff, fails with `TypeError: no implicit conversion of Symbol into String`. 

Also, since pp is required by default starting Ruby 2.5 and 2.4 is EOL, maybe it actually makes sense to include this extension into the core of the gem?