### PR TITLE
Adds support for module types

### DIFF
--- a/benchmarks/union.rb
+++ b/benchmarks/union.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "dry/struct/union"
+require "benchmark/ips"
+require "dry/types"
+
+module Country
+  include Dry::Struct.Union(include: %i[Scandinavia Germany])
+
+  module Types
+    include Dry::Types()
+  end
+
+  class Base < Dry::Struct
+    abstract
+  end
+
+  module Scandinavia
+    include Dry::Struct.Union(include: %i[Norway Sweden Denmark])
+
+    class Base < Country::Base
+      abstract
+      attribute :trade, Types.Array(Scandinavia)
+    end
+
+    class Norway < Base
+      attribute :id, Types.Value(:norway)
+      HASH = {id: :norway, trade: []}.freeze
+    end
+
+    class Sweden < Base
+      attribute :id, Types.Value(:sweden)
+      HASH = {id: :sweden, trade: [Norway::HASH]}.freeze
+    end
+
+    class Denmark < Base
+      attribute :id, Types.Value(:denmark)
+      HASH = {id: :denmark, trade: [Sweden::HASH, Norway::HASH]}.freeze
+    end
+
+    HASHES = [Norway::HASH, Sweden::HASH, Denmark::HASH].freeze
+  end
+
+  class Germany < Base
+    attribute :trade, Types.Array(Scandinavia)
+    attribute :id, Types.Value(:germany)
+    HASH = {id: :germany, trade: [Scandinavia::Denmark::HASH]}.freeze
+  end
+
+  HASHES = Scandinavia::HASHES + [Germany::HASH]
+end
+
+JOINED = [
+  Country::Scandinavia::Norway,
+  Country::Scandinavia::Sweden,
+  Country::Scandinavia::Denmark,
+  Country::Germany
+].reduce(:|)
+
+Benchmark.ips do |bm|
+  bm.report("Struct::Union") do
+    Country::HASHES.each do |hash|
+      Country.call(hash)
+    end
+  end
+
+  bm.report("Struct::Sum") do
+    Country::HASHES.each do |hash|
+      JOINED.call(hash)
+    end
+  end
+
+  bm.compare!
+end

--- a/lib/dry/struct.rb
+++ b/lib/dry/struct.rb
@@ -96,6 +96,7 @@ module Dry
     end
 
     autoload :Value, "dry/struct/value"
+    autoload :Union, "dry/struct/union"
 
     include ::Dry::Equalizer(:__attributes__, inspect: false, immutable: true)
 

--- a/lib/dry/struct/union.rb
+++ b/lib/dry/struct/union.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "dry/struct"
+
+module Dry
+  class Struct
+    # Allows modules to be treated structs ({Dry::Struct::Sum})
+    # Calls on the module get dispatched to {Constructor#sum}
+    # which is responsible for constructing a sum type consisting
+    # of constants within the module. The module can be shared by
+    # other constants as only the compatible types are selected
+    #
+    # @see [Struct.Union] for filtering and re-ordering options
+    #
+    # @example A module type of days of the week
+    #   module Day
+    #     include Dry::Struct::Union
+    #
+    #     class Monday < Dry::Struct
+    #       attribute :id, Types.Value(:monday)
+    #     end
+    #
+    #     class Tuesday < Dry::Struct
+    #       attribute :id, Types.Value(:tuesday)
+    #     end
+    #
+    #     # ...
+    #   end
+    #
+    #   Day.name # => Day<[Monday | Tuesday | ...]>
+    #   Day.call({ id: :monday }) # => Day::Monday
+    module Union
+      autoload :Constructor, "dry/struct/union/constructor"
+
+      # @private
+      def self.included(scope)
+        super
+        Union::Constructor.call(scope: scope)
+      end
+    end
+
+    # @see [Dry::Struct::Union]
+    #
+    # Allows the dispach receiver, {Constructor#sum} to be configued
+    # and re-ordered using {Union(exclude: [...], include: [...])}
+    #
+    # @option include: [Array<Symbol>] Constants to be included
+    # @option exclude: [Array<Symbol>] Constants to be excluded
+    # @raise [Dry::Struct::Error]
+    # @return [Module]
+    # @see [Union]
+    # @example A module consisting of planets, except 'Pluto'
+    #   module Planet
+    #     include Dry::Struct::Union(exclude: 'Pluto')
+    #
+    #     class Earth < Dry::Struct
+    #       attribute :id, Types.Value(:earth)
+    #     end
+    #
+    #     class Pluto < Dry::Struct
+    #       attribute :id, Types.Value(:pluto)
+    #     end
+    #
+    #     class Mars < Dry::Struct
+    #       attribute :id, Types.Value(:mars)
+    #     end
+    #   end
+    #
+    #   Planet.name # => Planet<[Earth | Mars]>
+    #   Planet.call({ id: :mars }) # => Planet::Mars
+    #   Planet.call({ id: :earth }) # => Planet::Earth
+    #   Planet.call({ id: :pluto }) # => raises Dry::Struct::Error
+    def self.Union(**options)
+      Module.new do
+        define_singleton_method(:included) do |scope|
+          super(scope)
+          Union::Constructor.call(scope: scope, **options)
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/struct/union/constructor.rb
+++ b/lib/dry/struct/union/constructor.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require "dry/core/constants"
+require "concurrent/map"
+require "dry/struct"
+require "dry/types"
+
+module Dry
+  class Struct
+    module Union
+      autoload :Extensions, "dry/struct/union/extensions"
+      # @private
+      class Constructor < Struct
+        using Extensions
+
+        module Types
+          include Dry::Types(default: :coercible)
+          Constants = Array.of(Symbol)
+        end
+
+        # @see Dry::Struct::Union
+        attribute? :include, Types::Constants.constrained(min_size: 1)
+        attribute :exclude, Types::Constants.default(EMPTY_ARRAY)
+        attribute :scope, Types::Instance(Module)
+        attribute(:cache, Types::Instance(Concurrent::Map).default do
+          Concurrent::Map.new do |store, key|
+            store.fetch_or_store(key, Concurrent::Map.new)
+          end
+        end)
+
+        using(Module.new {
+          refine Dry::Struct.singleton_class do
+            alias_method :__name__, :name
+          end
+        })
+
+        schema schema.strict
+
+        # Calls {#bind} and returns and instance of {Constructor}
+        #
+        # @return [Constructor]
+        def self.call(**options)
+          super(**options).tap(&:bind)
+        end
+
+        # Creates {Dry::Struct::Sum} type from types found in {#scope}
+        # Returns a lazy error {Types::Constructor) when {#types} is empty
+        # Calls are cached and expires when new constants appears on {#scope}
+        #
+        # @return [Dry::Struct::Sum]
+        def sum
+          compute_cache(:sum) do
+            types.reduce(:|) || Types.Constructor(Dry::Struct::Sum) do
+              raise Error, "No constructors found in [#{scope.__name__}]"
+            end
+          end
+        end
+
+        # Excludes constants passed by user via {exclude:}
+        # Includes constants passed by user via {include:}
+        # Falls back to local constants in {#scope}
+        # Uses {#constructor?} to exclude incompatible types
+        # @see {Extensions} for information about {#constructor?}
+        # @see {#sum} for information about caching
+        #
+        # @return [Array<#constructor?>]
+        def types
+          compute_cache(:types) do
+            (included - excluded).map(&method(:to_const)).select(&:constructor?)
+          end
+        end
+
+        # Pretty prints {#types}
+        # @see {#sum} for information about caching
+        #
+        # @return [String]
+        def name
+          compute_cache(:name) do
+            "%<name>s<[%<type>s]>" % {type: joined_types, name: scope.__name__}
+          end
+        end
+
+        # Used by {#types} to filter out usable types
+        #
+        # @return [Bool]
+        def constructor?
+          true
+        end
+
+        # Delegates calls on {#scope} to {#sum} and {#name}
+        # Maps all instance methods on {Dry::Struct::Sum} to {#scope}
+        #
+        # @return [Void]
+        # @private
+        def bind(constructor: self)
+          class << scope
+            alias_method :__name__, :name
+          end
+
+          %i[__sum__ __types__ constructor? name].each do |name|
+            scope.define_singleton_method(name) do |*args, &block|
+              constructor.__send__(name, *args, &block)
+            end
+          end
+
+          %i[try].each do |name|
+            scope.define_singleton_method(name) do |*args, &block|
+              constructor.sum.__send__(name, *args, &block)
+            end
+          end
+
+          Sum.instance_methods(true).each do |method|
+            next if scope.respond_to?(method)
+
+            scope.define_singleton_method(method) do |*args, &block|
+              constructor.sum.__send__(method, *args, &block)
+            end
+          end
+        end
+
+        private
+
+        def key
+          scope.constants(false).sort
+        end
+        alias_method :module_constants, :key
+
+        # All types to be used by {#types}
+        # The order specified will be preserved
+        # Falls back to local constants on {#scope}
+        #
+        # @return [Array<Symbol>]
+        def included
+          include || module_constants
+        end
+
+        # Cache handler used by the public API
+        #
+        # @name [Symbol] Method name
+        # @block [Proc] To be cached
+        # @return [Any]
+        def compute_cache(name, &block)
+          cache[key][name] ||= block.call
+        end
+
+        # Renders {#types} on the form "Type2 | Type2 | ..."
+        # Falls back to "Unknown" when type has no name
+        #
+        # @return [String]
+        def joined_types
+          types.map { |t| t.__name__ || "Unknown" }.join(" | ")
+        end
+
+        # Retrieves the given constant from {#scope}
+        #
+        # @name [Symbol] Constant name
+        # @return [Constant] The constant
+        # @raise [Error] When {name} cannot be found
+        def to_const(name)
+          scope.const_get(name)
+        rescue NameError
+          raise Error, "Constant [#{name}] not defined in [#{scope.__name__}]"
+        end
+
+        # Renamed to be inline with {#included}
+        alias_method :excluded, :exclude
+        # Bound to {Union}s public interface
+        alias_method :__types__, :types
+        alias_method :__sum__, :sum
+      end
+    end
+  end
+end

--- a/lib/dry/struct/union/extensions.rb
+++ b/lib/dry/struct/union/extensions.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "dry/struct"
+
+module Dry
+  class Struct
+    module Union
+      # Used to identify compatible types without manual dispatching
+      # Extend this module with a refinment to introduce new types
+      #
+      # @see [Constructor#types]
+      # @example Introduce {Dry::Types::Type} as a compatible type
+      #  refine Dry::Types::Type do
+      #    def constructor?
+      #      true
+      #    end
+      #  end
+      # @private
+      module Extensions
+        refine Dry::Struct.singleton_class do
+          # True for non-abstract structs
+          #
+          # @return [Boolean]
+          def constructor?
+            abstract_class != self
+          end
+        end
+
+        refine BasicObject do
+          # Fallback implementation for incompatible objects
+          #
+          # @return [Boolean]
+          def constructor?
+            false
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/union_spec.rb
+++ b/spec/integration/union_spec.rb
@@ -1,81 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.describe Dry::Struct::Union do
-  module Solar
-    class Base < Dry::Struct
-      abstract
-      schema schema.strict
-    end
-
-    module Types
-      include Dry::Types()
-    end
-
-    module Weather
-      include Dry::Struct.Union(include: [:Warm])
-      MAX_TEMP = 274
-
-      class Base < Solar::Base
-        abstract
-        attribute :temp, "integer"
-      end
-
-      class Cold < Base
-        attribute :id, Types.Value(:cold)
-      end
-
-      class Warm < Base
-        attribute :id, Types.Value(:warm)
-      end
-    end
-
-    module Season
-      include Dry::Struct::Union
-
-      class Spring < Solar::Base
-        attribute :id, Types.Value(:spring)
-      end
-
-      module Unused
-        class Autum < Solar::Base
-          attribute :id, Types.Value(:autum)
-        end
-      end
-    end
-
-    module Planet
-      include Dry::Struct.Union(exclude: :Pluto)
-
-      class Base < Solar::Base
-        abstract
-        attribute? :closest, Planet
-        attribute? :season, Season
-        attribute? :weather, Weather
-      end
-
-      class Pluto < Base
-        attribute :id, Types.Value(:pluto)
-      end
-
-      class Earth < Base
-        attribute :id, Types.Value(:earth)
-      end
-
-      class Mars < Base
-        attribute :id, Types.Value(:mars)
-      end
-    end
-  end
-
-  describe Solar do
-    let(:remove) { "" }
+  describe Union::Example do
     let(:cold) { {id: :cold, temp: 100} }
     let(:warm) { {id: :warm, temp: 100} }
     let(:spring) { {id: :spring} }
 
     describe described_class::Weather do
       describe ".name" do
-        it { is_expected.to have_attributes(name: "#{remove}Solar::Weather<[#{remove}Solar::Weather::Warm]>") }
+        it { is_expected.to have_attributes(name: "Union::Example::Weather<[Union::Example::Weather::Warm]>") }
       end
 
       describe ".call" do
@@ -99,7 +32,7 @@ RSpec.describe Dry::Struct::Union do
       let(:mars) { {id: :mars, closest: earth, weather: warm} }
 
       describe ".name" do
-        it { is_expected.to have_attributes(name: "#{remove}Solar::Planet<[#{remove}Solar::Planet::Earth | #{remove}Solar::Planet::Mars]>") }
+        it { is_expected.to have_attributes(name: "Union::Example::Planet<[Union::Example::Planet::Earth | Union::Example::Planet::Mars]>") }
       end
 
       describe ".call" do
@@ -127,7 +60,7 @@ RSpec.describe Dry::Struct::Union do
 
     describe described_class::Season do
       describe ".name" do
-        it { is_expected.to have_attributes(name: "#{remove}Solar::Season<[#{remove}Solar::Season::Spring]>") }
+        it { is_expected.to have_attributes(name: "Union::Example::Season<[Union::Example::Season::Spring]>") }
       end
 
       describe ".call" do

--- a/spec/integration/union_spec.rb
+++ b/spec/integration/union_spec.rb
@@ -81,8 +81,6 @@ RSpec.describe Dry::Struct::Union do
   end
 
   describe "edge cases" do
-    subject { self.class::Type }
-
     describe ".call" do
       context "given an empty type union" do
         subject do
@@ -95,16 +93,19 @@ RSpec.describe Dry::Struct::Union do
       end
 
       context "given a type module with nothing excluded" do
-        module self::Type
-          include Dry::Struct::Union
-
-          class A < Dry::Struct
-            # NOP
+        subject(:scope) do
+          Module.new do
+            include Dry::Struct::Union
           end
         end
 
-        subject { self.class::Type }
-        it { is_expected.to have_attributes(__types__: [self.class::Type::A]) }
+        let(:struct) { Class.new(Dry::Struct) }
+
+        before do
+          scope.const_set("Struct", struct)
+        end
+
+        it { is_expected.to have_attributes(__types__: [struct]) }
       end
     end
   end

--- a/spec/integration/union_spec.rb
+++ b/spec/integration/union_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Struct::Union do
+  module Solar
+    class Base < Dry::Struct
+      abstract
+      schema schema.strict
+    end
+
+    module Types
+      include Dry::Types()
+    end
+
+    module Weather
+      include Dry::Struct.Union(include: [:Warm])
+      MAX_TEMP = 274
+
+      class Base < Solar::Base
+        abstract
+        attribute :temp, "integer"
+      end
+
+      class Cold < Base
+        attribute :id, Types.Value(:cold)
+      end
+
+      class Warm < Base
+        attribute :id, Types.Value(:warm)
+      end
+    end
+
+    module Season
+      include Dry::Struct::Union
+
+      class Spring < Solar::Base
+        attribute :id, Types.Value(:spring)
+      end
+
+      module Unused
+        class Autum < Solar::Base
+          attribute :id, Types.Value(:autum)
+        end
+      end
+    end
+
+    module Planet
+      include Dry::Struct.Union(exclude: :Pluto)
+
+      class Base < Solar::Base
+        abstract
+        attribute? :closest, Planet
+        attribute? :season, Season
+        attribute? :weather, Weather
+      end
+
+      class Pluto < Base
+        attribute :id, Types.Value(:pluto)
+      end
+
+      class Earth < Base
+        attribute :id, Types.Value(:earth)
+      end
+
+      class Mars < Base
+        attribute :id, Types.Value(:mars)
+      end
+    end
+  end
+
+  describe Solar do
+    let(:remove) { "" }
+    let(:cold) { {id: :cold, temp: 100} }
+    let(:warm) { {id: :warm, temp: 100} }
+    let(:spring) { {id: :spring} }
+
+    describe described_class::Weather do
+      describe ".name" do
+        it { is_expected.to have_attributes(name: "#{remove}Solar::Weather<[#{remove}Solar::Weather::Warm]>") }
+      end
+
+      describe ".call" do
+        describe "Warm" do
+          subject { described_class.call(warm) }
+          it { is_expected.to be_a(described_class::Warm) }
+        end
+
+        describe "Cold" do
+          it "throws an error" do
+            expect do
+              described_class.call(cold)
+            end.to raise_error(Dry::Struct::Error)
+          end
+        end
+      end
+    end
+
+    describe described_class::Planet do
+      let(:earth) { {id: :earth, weather: warm, season: spring} }
+      let(:mars) { {id: :mars, closest: earth, weather: warm} }
+
+      describe ".name" do
+        it { is_expected.to have_attributes(name: "#{remove}Solar::Planet<[#{remove}Solar::Planet::Earth | #{remove}Solar::Planet::Mars]>") }
+      end
+
+      describe ".call" do
+        describe "Mars" do
+          subject { described_class.call(mars) }
+          it { is_expected.to be_a(described_class::Mars) }
+          it { is_expected.to have_attributes(to_h: mars) }
+        end
+
+        describe "Earth" do
+          subject { described_class.call(earth) }
+          it { is_expected.to be_a(described_class::Earth) }
+          it { is_expected.to have_attributes(to_h: earth) }
+        end
+
+        describe "Pluto" do
+          it "throws an error" do
+            expect do
+              described_class.call({id: :pluto})
+            end.to raise_error(Dry::Struct::Error)
+          end
+        end
+      end
+    end
+
+    describe described_class::Season do
+      describe ".name" do
+        it { is_expected.to have_attributes(name: "#{remove}Solar::Season<[#{remove}Solar::Season::Spring]>") }
+      end
+
+      describe ".call" do
+        describe "Spring" do
+          subject { described_class.call(spring) }
+          it { is_expected.to be_a(described_class::Spring) }
+        end
+
+        describe "Autum" do
+          it "throws an error" do
+            expect do
+              described_class.call({id: :autum})
+            end.to raise_error(Dry::Struct::Error)
+          end
+        end
+      end
+    end
+  end
+
+  describe "edge cases" do
+    subject { self.class::Type }
+
+    describe ".call" do
+      context "given an empty type union" do
+        subject do
+          Module.new do
+            include Dry::Struct::Union
+          end
+        end
+
+        it { is_expected.to have_attributes(__types__: []) }
+      end
+
+      context "given a type module with nothing excluded" do
+        module self::Type
+          include Dry::Struct::Union
+
+          class A < Dry::Struct
+            # NOP
+          end
+        end
+
+        subject { self.class::Type }
+        it { is_expected.to have_attributes(__types__: [self.class::Type::A]) }
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require_relative "support/coverage"
 require_relative "support/warnings"
+require_relative "support/union"
 
 require "pathname"
 

--- a/spec/support/union.rb
+++ b/spec/support/union.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "dry/struct/union"
+
+module Union
+  module Reopen
+    module Type
+      include Dry::Struct::Union
+    end
+
+    module Type
+      class InnerA < Dry::Struct
+        attribute :id, "integer"
+      end
+    end
+
+    module Type
+      class InnerB < Dry::Struct
+        attribute :id, "string"
+      end
+    end
+  end
+
+  module Example
+    class Base < Dry::Struct
+      abstract
+      schema schema.strict
+    end
+
+    module Types
+      include Dry::Types()
+    end
+
+    module Weather
+      include Dry::Struct.Union(include: [:Warm])
+      MAX_TEMP = 274
+
+      class Base < Example::Base
+        abstract
+        attribute :temp, "integer"
+      end
+
+      class Cold < Base
+        attribute :id, Types.Value(:cold)
+      end
+
+      class Warm < Base
+        attribute :id, Types.Value(:warm)
+      end
+    end
+
+    module Season
+      include Dry::Struct::Union
+
+      class Spring < Example::Base
+        attribute :id, Types.Value(:spring)
+      end
+
+      module Unused
+        class Autum < Example::Base
+          attribute :id, Types.Value(:autum)
+        end
+      end
+    end
+
+    module Planet
+      include Dry::Struct.Union(exclude: :Pluto)
+
+      class Base < Example::Base
+        abstract
+        attribute? :closest, Planet
+        attribute? :season, Season
+        attribute? :weather, Weather
+      end
+
+      class Pluto < Base
+        attribute :id, Types.Value(:pluto)
+      end
+
+      class Earth < Base
+        attribute :id, Types.Value(:earth)
+      end
+
+      class Mars < Base
+        attribute :id, Types.Value(:mars)
+      end
+    end
+  end
+end

--- a/spec/unit/union/constructor_spec.rb
+++ b/spec/unit/union/constructor_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+describe Dry::Struct::Union::Constructor do
+  describe ".new" do
+    let(:error) { Dry::Struct::Error }
+
+    let(:type) do
+      Module.new do
+        include Dry::Struct::Union
+      end
+    end
+
+    let(:params) do
+      {scope: type}
+    end
+
+    describe "scope:" do
+      context "given a union type" do
+        let(:type) do
+          Module.new do
+            include Dry::Struct::Union
+          end
+        end
+
+        it "raises no error" do
+          expect { described_class.new(**params, scope: type) }.not_to raise_error
+        end
+      end
+    end
+
+    describe "include:" do
+      context "given a non-existing constant" do
+        it "raises error" do
+          expect { described_class.new(**params, include: ["DoesNotExist"]).sum.call({}) }.to raise_error(Dry::Struct::Error)
+        end
+      end
+
+      describe "array" do
+        context "given an empty list" do
+          it "raises error" do
+            expect { described_class.new(**params, include: []) }.to raise_error(error)
+          end
+        end
+
+        context "given not :include" do
+          let(:params) { super().merge(include: nil).compact }
+
+          it "raises no error" do
+            expect { described_class.new(**params) }.not_to raise_error
+          end
+        end
+
+        context "given [Symbol]" do
+          it "raises no error" do
+            expect { described_class.new(**params, include: [:Object]) }.not_to raise_error
+          end
+        end
+
+        context "given a number" do
+          it "raises error" do
+            expect { described_class.new(**params, include: [10]) }.to raise_error(error)
+          end
+        end
+
+        context "given a [String]" do
+          it "raises no error" do
+            expect { described_class.new(**params, include: ["Object"]) }.not_to raise_error
+          end
+        end
+      end
+
+      describe "value" do
+        context "given a [String]" do
+          it "raises no error" do
+            expect { described_class.new(**params, include: "Object") }.not_to raise_error
+          end
+        end
+
+        context "given a number" do
+          it "raises error" do
+            expect { described_class.new(**params, include: 10) }.to raise_error(error)
+          end
+        end
+      end
+    end
+
+    describe "exclude:" do
+      context "given a non-existing constant" do
+        it "raises error" do
+          expect { described_class.new(**params, exclude: ["DoesNotExist"]).sum.call({}) }.to raise_error(Dry::Types::CoercionError)
+        end
+      end
+
+      describe "array" do
+        context "given an empty list" do
+          it "raises no error" do
+            expect { described_class.new(**params, exclude: []) }.not_to raise_error
+          end
+        end
+
+        context "given not :exclude" do
+          let(:params) { super().merge(exclude: nil).compact }
+
+          it "raises no error" do
+            expect { described_class.new(**params) }.not_to raise_error
+          end
+        end
+
+        context "given [Symbol]" do
+          it "raises no error" do
+            expect { described_class.new(**params, exclude: [:Object]) }.not_to raise_error
+          end
+        end
+
+        context "given a number" do
+          it "raises error" do
+            expect { described_class.new(**params, exclude: [10]) }.to raise_error(error)
+          end
+        end
+
+        context "given a [String]" do
+          it "raises no error" do
+            expect { described_class.new(**params, exclude: ["Object"]) }.not_to raise_error
+          end
+        end
+      end
+
+      describe "value" do
+        context "given a [String]" do
+          it "raises no error" do
+            expect { described_class.new(**params, exclude: "Object") }.not_to raise_error
+          end
+        end
+
+        context "given a number" do
+          it "raises error" do
+            expect { described_class.new(**params, exclude: 10) }.to raise_error(error)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/union_spec.rb
+++ b/spec/unit/union_spec.rb
@@ -22,43 +22,17 @@ describe Dry::Struct::Union do
   end
 
   describe "reopened module type" do
-    let(:type) { self.class::Type }
+    let(:type) { Union::Reopen::Type }
 
     context "given [include ::Union] is added later" do
-      module self::Type
-        # NOP
-      end
-
-      module self::Type
-        include Dry::Struct::Union
-
-        class Inner < Dry::Struct
-          # NOP
-        end
-      end
-
       context "given .call({})" do
         it "returns type" do
-          expect(type.call({})).to be_a(type::Inner)
+          expect(type.call({id: 2000})).to be_a(type::InnerA)
         end
       end
     end
 
     context "given a later struct" do
-      module self::Type
-        include Dry::Struct::Union
-
-        class InnerA < Dry::Struct
-          attribute :id, "integer"
-        end
-      end
-
-      module self::Type
-        class InnerB < Dry::Struct
-          attribute :id, "string"
-        end
-      end
-
       context "given .call matching [A]" do
         it "returns A" do
           expect(type.call({id: 1000})).to be_a(type::InnerA)

--- a/spec/unit/union_spec.rb
+++ b/spec/unit/union_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+describe Dry::Struct::Union do
+  context "given a union" do
+    it "raises no error" do
+      expect do
+        Module.new do
+          include Dry::Struct::Union
+        end
+      end.to_not raise_error
+    end
+  end
+
+  context "given a class" do
+    it "raises no error" do
+      expect do
+        Class.new do
+          include Dry::Struct::Union
+        end
+      end.to_not raise_error
+    end
+  end
+
+  describe "reopened module type" do
+    let(:type) { self.class::Type }
+
+    context "given [include ::Union] is added later" do
+      module self::Type
+        # NOP
+      end
+
+      module self::Type
+        include Dry::Struct::Union
+
+        class Inner < Dry::Struct
+          # NOP
+        end
+      end
+
+      context "given .call({})" do
+        it "returns type" do
+          expect(type.call({})).to be_a(type::Inner)
+        end
+      end
+    end
+
+    context "given a later struct" do
+      module self::Type
+        include Dry::Struct::Union
+
+        class InnerA < Dry::Struct
+          attribute :id, "integer"
+        end
+      end
+
+      module self::Type
+        class InnerB < Dry::Struct
+          attribute :id, "string"
+        end
+      end
+
+      context "given .call matching [A]" do
+        it "returns A" do
+          expect(type.call({id: 1000})).to be_a(type::InnerA)
+        end
+      end
+
+      context "given .call matching [B]" do
+        it "returns B" do
+          expect(type.call({id: "string"})).to be_a(type::InnerB)
+        end
+      end
+
+      context "given .call matching nothing" do
+        it "raises error" do
+          expect { type.call({id: nil}) }.to raise_error(Dry::Struct::Error)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In a nutshell, this PR allows modules to behave like structs by dispatching calls to an internal `Dry::Struct::Sum` type constructed from local structs and modules.

This is easiest shown with an example:

``` ruby
# Season<[Summer | Winter | Autumn | Spring]>
module Season
  include Dry::Struct::Union

  class Summer < Dry::Struct
    attribute :id, Types.value('summer')
  end

  class Autumn < Dry::Struct
     attribute :id, Types.value('autumn')
  end

  class Winter < Dry::Struct
      attribute :id, Types.value('winter')
  end

  class Spring < Dry::Struct
     attribute :id, Types.value('spring')
  end
end

Season.call({ id: 'summer' }) # => Season::Summer
Season.name # => Season<[Summer | ...]>
```

It uses `Module#constants` internally to locate compatible types within its module, which also automatically dispatches calls to. Unwanted constants, such as abstract and non-structs are automatically filtered out and can be configured further by calling the `.Union` method. It allows the sum type to be ordered and further limited according to the developers' needs.

``` ruby
# Planet<[Earth | Mars]>
module Planet
  include Dry::Struct.Union(exclude: :Pluto)
	
  class Earth < Dry::Struct
    # NOP
  end
	
  class Pluto < Dry::Struct
    # NOP
  end

  class Mars < Dry::Struct
    # NOP
  end
end
```

Modules can be nested:

``` ruby
module Thing
  include Dry::Struct::Union

  module Fruit
    include Dry::Struct::Union

    class Apple < Dry::Struct
      attribute :id, Types.Value('apple')
    end

    class Melon < Dry::Struct
      attribute :id, Types.Value('melon')
    end
  end

  module Car
    include Dry::Struct::Union

    class Volvo < Dry::Struct
      attribute :id, Types.Value('volvo')
    end

    class Mercedes < Dry::Struct
      attribute :id, Types.Value('mercedes')
    end
  end
end

Thing.call({ id: 'volvo' }) # => Thing::Car::Volvo
```

Union modules can be referenced recursively and play well with classes stubbed by autoloaders like Zeitwerk. Performance-wise, a union type adds about ~10-15% of overhead vs a static defined sum type like `Planet = Earth | Mars`. 

This library was extracted out from an existing project implementing a transpiler consisting of over 350  `Dry::Struct` classes representing an AST. It was designed to reduce coupling between structs by allow modules to behave like the sum of their internals.  This allowed for a more streamlined API as collections of structs could be interacted with, without having to dig into the internals of the module.

## Benchmarks

See `benchmarks/union`

```
Warming up --------------------------------------
       Struct::Union   747.000  i/100ms
         Struct::Sum   894.000  i/100ms
Calculating -------------------------------------
       Struct::Union      7.820k (± 5.3%) i/s -     39.591k in   5.077865s
         Struct::Sum      8.920k (± 4.0%) i/s -     44.700k in   5.019379s

Comparison:
         Struct::Sum:     8920.1 i/s
       Struct::Union:     7820.5 i/s - 1.14x  (± 0.00) slower
```

We've been running this feature in production at my current company for about 5 months so thought I would share it with the community that made it possible. Due to its size, I'm not expecting it to be merged, but rather start a discussion on similar features that might be useful to hide boilerplate.

Don't get me wrong tho, I would be more than happy if it was accepted ツ 

❤️ 