### PR TITLE
Updates ClassInstance#try to build failure obj using Dry::Types::Error obj instead String

### DIFF
--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -306,7 +306,7 @@ module Dry
       def try(input)
         success(self[input])
       rescue Error => e
-        failure_result = failure(input, e.message)
+        failure_result = failure(input, e)
         block_given? ? yield(failure_result) : failure_result
       end
 

--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -301,7 +301,7 @@ module Dry
 
       # @param [Hash{Symbol => Object},Dry::Struct] input
       # @yieldparam [Dry::Types::Result::Failure] failure
-      # @yieldreturn [Dry::Types::ResultResult]
+      # @yieldreturn [Dry::Types::Result]
       # @return [Dry::Types::Result]
       def try(input)
         success(self[input])

--- a/spec/integration/attribute_dsl/nested_struct_spec.rb
+++ b/spec/integration/attribute_dsl/nested_struct_spec.rb
@@ -267,4 +267,24 @@ RSpec.describe Dry::Struct, method: ".attribute" do
       expect(Test::Foo.valid?("address" => [city: "London"])).to be(true)
     end
   end
+
+  context "when given a class as nested type with a mapped attribute" do
+    module DryTypes
+      include Dry.Types()
+    end
+
+    class NestedStruct < Dry::Struct
+      attribute :something, DryTypes::String
+    end
+
+    class TestStruct < Dry::Struct
+      attribute :hash, DryTypes::Hash.map(DryTypes::Coercible::Symbol, NestedStruct)
+    end
+
+    it "throws a dry error if a nested attribute is missing" do
+      expect do
+        TestStruct.new({hash: {first: {}}})
+      end.to raise_exception(Dry::Struct::Error)
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/dry-rb/dry-struct/issues/175

### Summary

When building a nested struct using `DryTypes::Hash.map(...)` as attribute type  and initializing this struct with an invalid hash key for its attribute value...

```ruby
module DryTypes
  include Dry.Types()
end

class NestedStruct < Dry::Struct
  attribute :something, DryTypes::String
end

class TestStruct < Dry::Struct
  attribute :hash, DryTypes::Hash.map(DryTypes::Coercible::Symbol, NestedStruct)
end
```

... it raises the following error:

**NOTE**: note that we are passing `:first` as attribute key instead of `:something` for `TestStruct` `:hash` attribute value.


```ruby
TestStruct.new({ hash: { first: {} } })
#> expected Dry::Struct::Error, got #<NoMethodError: undefined method `message' for "[NestedStruct.new] :something is missing in Hash input":String> with backtrace:
         # ./lib/dry/struct/class_interface.rb:264:in `new'
```



### Update

This PR updates `ClassInterface#try` to pass `Types::Result::Failure` error arg as `Dry::Struct::Error` obj instead of `String` to make it more consistent with:

1. `Dry::Types::MultipleError#initialize` expects (`@param [Array<CoercionError>] errors` - [See](https://github.com/dry-rb/dry-types/blob/main/lib/dry/types/errors.rb#L52)). 
2. `Dry::Types::MultipleError#message` expects errors items to respond to `:message`. [See](https://github.com/dry-rb/dry-types/blob/main/lib/dry/types/errors.rb#L60)
