### PR TITLE
Move PrettyPrint to Extensions namespace

### DIFF
--- a/lib/dry/struct.rb
+++ b/lib/dry/struct.rb
@@ -99,7 +99,8 @@ module Dry
           loader.push_dir(root)
           loader.ignore(
             "#{root}/dry-struct.rb",
-            "#{root}/dry/struct/{class_interface,errors,extensions,printer,value,version}.rb"
+            "#{root}/dry/struct/{class_interface,errors,extensions,printer,value,version}.rb",
+            "#{root}/dry/struct/extensions"
           )
         end
       end


### PR DESCRIPTION
~~I had to remove `extensions` from zeitwerk's ignored list and move `PrettyPrint` to `Extensions::PrettyPrint` so that the file structure matches namespaces (otherwise Zeitwerk complains, which is expected).~~

~~I did not fully track down which specific line caused the original issue, as in, I do not know what refers to `Extensions` that cause auto-loading of that module and not finding anything (since `extensions` was ignored in the loader config).~~

~~Anyhow, I reckon this should do it and it doesn't break anything else (famous last words 🤣)~~

So, actually, adding `extensions.rb` and `extensions` dir did the trick too.

Fixes #183