### PR TITLE
Keep original error in failure object

### DIFF
--- a/lib/dry/struct/class_interface.rb
+++ b/lib/dry/struct/class_interface.rb
@@ -306,7 +306,7 @@ module Dry
       def try(input)
         success(self[input])
       rescue Error => e
-        failure_result = failure(input, e.message)
+        failure_result = failure(input, e)
         block_given? ? yield(failure_result) : failure_result
       end
 

--- a/spec/shared/struct.rb
+++ b/spec/shared/struct.rb
@@ -310,6 +310,10 @@ RSpec.shared_examples_for Dry::Struct do
         expect(struct.try(name: "John")).to be_a(Dry::Types::Result::Success)
         expect(struct.try(name: 42)).to be_a(Dry::Types::Result::Failure)
       end
+
+      it "keeps an error instance" do
+        expect(struct.try(name: 42).error).to be_a(Dry::Struct::Error)
+      end
     end
   end
 end


### PR DESCRIPTION
It should have worked like this from the very beginning (dry-types keeps exception instances there). I'll do some testing against my production code, just to make sure this doesn't break things.