### PR TITLE
byebugs currently unsupported by JRuby

### DIFF
--- a/Gemfile.devtools
+++ b/Gemfile.devtools
@@ -14,5 +14,5 @@ end
 
 group :tools do
   gem "rubocop", "~> 1.40.0"
-  gem "byebug"
+  gem "byebug", platforms: :ruby
 end


### PR DESCRIPTION
Just a simple platforms qualifier to exclude it when run from JRuby.