### PR TITLE
Add class name to missing attribute error

### DIFF
--- a/lib/dry/struct.rb
+++ b/lib/dry/struct.rb
@@ -145,7 +145,7 @@ module Dry
     #   rom_n_roda[:title] #=> 'Web Development with ROM and Roda'
     #   rom_n_roda[:subtitle] #=> nil
     def [](name)
-      @attributes.fetch(name) { raise MissingAttributeError, name }
+      @attributes.fetch(name) { raise MissingAttributeError, {name: name, klass: self.class} }
     end
 
     # Converts the {Dry::Struct} to a hash with keys representing

--- a/lib/dry/struct.rb
+++ b/lib/dry/struct.rb
@@ -145,7 +145,9 @@ module Dry
     #   rom_n_roda[:title] #=> 'Web Development with ROM and Roda'
     #   rom_n_roda[:subtitle] #=> nil
     def [](name)
-      @attributes.fetch(name) { raise MissingAttributeError.new(attribute: name, klass: self.class) }
+      @attributes.fetch(name) do
+        raise MissingAttributeError.new(attribute: name, klass: self.class)
+      end
     end
 
     # Converts the {Dry::Struct} to a hash with keys representing

--- a/lib/dry/struct.rb
+++ b/lib/dry/struct.rb
@@ -145,7 +145,7 @@ module Dry
     #   rom_n_roda[:title] #=> 'Web Development with ROM and Roda'
     #   rom_n_roda[:subtitle] #=> nil
     def [](name)
-      @attributes.fetch(name) { raise MissingAttributeError, {name: name, klass: self.class} }
+      @attributes.fetch(name) { raise MissingAttributeError.new(attribute: name, klass: self.class) }
     end
 
     # Converts the {Dry::Struct} to a hash with keys representing

--- a/lib/dry/struct/errors.rb
+++ b/lib/dry/struct/errors.rb
@@ -16,8 +16,8 @@ module Dry
 
     # Raised when a struct doesn't have an attribute
     class MissingAttributeError < ::KeyError
-      def initialize(data)
-        super("Missing attribute: #{data[:name].inspect} on #{data[:klass]}")
+      def initialize(attribute:, klass:)
+        super("Missing attribute: #{attribute.inspect} on #{klass}")
       end
     end
 

--- a/lib/dry/struct/errors.rb
+++ b/lib/dry/struct/errors.rb
@@ -16,8 +16,8 @@ module Dry
 
     # Raised when a struct doesn't have an attribute
     class MissingAttributeError < ::KeyError
-      def initialize(key)
-        super("Missing attribute: #{key.inspect}")
+      def initialize(data)
+        super("Missing attribute: #{data[:name].inspect} on #{data[:klass]}")
       end
     end
 

--- a/spec/integration/struct_spec.rb
+++ b/spec/integration/struct_spec.rb
@@ -353,7 +353,7 @@ RSpec.describe Dry::Struct do
 
       expect { value[:name] }
         .to raise_error(Dry::Struct::MissingAttributeError)
-        .with_message("Missing attribute: :name")
+        .with_message("Missing attribute: :name on Test::Task")
     end
 
     describe "protected methods" do


### PR DESCRIPTION
I saw this original PR (#170) was closed due to the fork of dry-struct being deleted by the author. 

I think this is a valuable contribution that should be included (and it's a contribution I would make myself if I had come across the issue), so I'm opening this PR. I also refactored it a little bit to use kwargs.