### PR TITLE
Fix bugs with coercing input to arrays of struct types

### DIFF
--- a/Gemfile.devtools
+++ b/Gemfile.devtools
@@ -17,4 +17,8 @@ group :tools do
   gem "rubocop", "~> 1.69.2"
   gem "byebug"
   gem "yard"
+
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0")
+    gem "debug"
+  end
 end

--- a/changelog.yml
+++ b/changelog.yml
@@ -2,10 +2,15 @@
 - version: 1.7.0
   summary:
   date: 2025-01-04
+  fixed:
+  - 'Fixed coercion errors for structs (issue #192 via #193)
+    (@flash-gordon)'
   changed:
   - 'Missing attribute error now includes the name of the class (issue #170 via #191)
     (@phillipoertel + @cllns)'
   - '3.1 is now the minimum Ruby version (@flash-gordon)'
+  - '`Dry::Struct::Error` is now a subclass of `Dry::Types::CoercionError` (in #193)
+    (@flash-gordon)'
 - version: 1.6.0
   date: 2022-11-04
   changed:

--- a/lib/dry/struct/errors.rb
+++ b/lib/dry/struct/errors.rb
@@ -3,7 +3,7 @@
 module Dry
   class Struct
     # Raised when given input doesn't conform schema and constructor type
-    Error = Class.new(TypeError)
+    Error = Class.new(::Dry::Types::CoercionError)
 
     # Raised when defining duplicate attributes
     class RepeatedAttributeError < ::ArgumentError

--- a/lib/dry/struct/sum.rb
+++ b/lib/dry/struct/sum.rb
@@ -18,7 +18,7 @@ module Dry
       # @return [Dry::Types::Result]
       def try(input)
         if input.is_a?(Struct)
-          try_struct(input) { super }
+          ::Dry::Types::Result::Success.new(try_struct(input) { return super })
         else
           super
         end

--- a/spec/integration/array_spec.rb
+++ b/spec/integration/array_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Types::Array do
+  before do
+    module Test
+      class Street < Dry::Struct
+        attribute :street_name, "string"
+      end
+
+      class City < Dry::Struct
+        attribute :city_name, "string"
+      end
+
+      CityOrStreet = City | Street
+    end
+  end
+
+  describe "#try" do
+    context "simple struct" do
+      subject(:array) { Dry::Types["array"].of(Test::Street) }
+      it "returns success for valid array" do
+        expect(array.try([{street_name: "Oxford"}, {street_name: "London"}])).to be_success
+      end
+
+      it "returns failure for invalid array" do
+        expect(array.try([{name: "Oxford"}, {name: 123}])).to be_failure
+        expect(array.try([{}])).to be_failure
+      end
+    end
+
+    context "sum struct" do
+      subject(:array) { Dry::Types["array"].of(Test::CityOrStreet) }
+
+      it "returns success for valid array" do
+        expect(array.try([{city_name: "London"}, {street_name: "Oxford"}])).to be_success
+        expect(array.try([Test::Street.new(street_name: "Oxford")])).to be_success
+      end
+
+      it "returns failure for invalid array" do
+        expect(array.try([{city_name: "London"}, {street_name: 123}])).to be_failure
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,10 +18,12 @@ $VERBOSE = true
 
 require "dry-struct"
 
-begin
-  require "pry"
-  require "pry-byebug"
+%w[debug pry-byebug pry byebug].each do |gem|
+  require gem
 rescue LoadError
+  nil
+else
+  break
 end
 
 Dir[Pathname(__dir__).join("shared/*.rb")].each(&method(:require))


### PR DESCRIPTION
This changes the base class for `Dry::Struct::Error` to `Dry::Types::CoercionError`. It solves one of the bugs but it also makes sense in general.